### PR TITLE
Open links via terminal in both MacOSX and Linux

### DIFF
--- a/lib/bullet_train/super_scaffolding/scaffolders/oauth_provider_scaffolder.rb
+++ b/lib/bullet_train/super_scaffolding/scaffolders/oauth_provider_scaffolder.rb
@@ -61,7 +61,7 @@ module BulletTrain
             puts "When you find one you like, hover your mouse over it and then come back here and"
             puts "and enter the name of the icon you want to use."
             response = STDIN.gets.chomp
-            TerminalCommands.open_link_or_file("http://light.pinsupreme.com/icon_fonts_themefy.html")
+            TerminalCommands.open_file_or_link("http://light.pinsupreme.com/icon_fonts_themefy.html")
             puts ""
             puts "Did you find an icon you wanted to use? Enter the name here or hit enter to just"
             puts "use the dollar symbol:"

--- a/lib/bullet_train/super_scaffolding/scaffolders/oauth_provider_scaffolder.rb
+++ b/lib/bullet_train/super_scaffolding/scaffolders/oauth_provider_scaffolder.rb
@@ -61,7 +61,7 @@ module BulletTrain
             puts "When you find one you like, hover your mouse over it and then come back here and"
             puts "and enter the name of the icon you want to use."
             response = STDIN.gets.chomp
-            `open http://light.pinsupreme.com/icon_fonts_themefy.html`
+            TerminalCommands.open_link_or_file("http://light.pinsupreme.com/icon_fonts_themefy.html")
             puts ""
             puts "Did you find an icon you wanted to use? Enter the name here or hit enter to just"
             puts "use the dollar symbol:"

--- a/lib/bullet_train/terminal_commands.rb
+++ b/lib/bullet_train/terminal_commands.rb
@@ -1,0 +1,30 @@
+module TerminalCommands
+  def self.open_file_or_link(file_or_link, options = {})
+    command = if macosx?
+      "open"
+    elsif linux?
+      "xdg-open"
+    end
+    `#{command} #{file_or_link}`
+  end
+
+  def self.os
+    Gem::Platform.local.os
+  end
+
+  def self.macosx?
+    os == macosx
+  end
+
+  def self.linux?
+    os == linux
+  end
+
+  def self.macosx
+    "darwin"
+  end
+
+  def self.linux
+    "linux"
+  end
+end

--- a/lib/scaffolding/script.rb
+++ b/lib/scaffolding/script.rb
@@ -8,6 +8,8 @@ require "scaffolding/class_names_transformer"
 require "scaffolding/oauth_providers"
 require "scaffolding/routes_file_manipulator"
 
+require_relative "../bullet_train/terminal_commands"
+
 # filter out options.
 argv = []
 @options = {}

--- a/lib/scaffolding/transformer.rb
+++ b/lib/scaffolding/transformer.rb
@@ -1346,7 +1346,7 @@ class Scaffolding::Transformer
             puts "OK, great! Let's do this! By default these menu items appear with a puzzle piece, but after you hit enter I'll open two different pages where you can view other icon options. When you find one you like, hover your mouse over it and then come back here and and enter the name of the icon you want to use. (Or hit enter to skip this step.)"
             $stdin.gets.chomp
             if `which open`.present?
-              TerminalCommands.open_file_or_link("https://themify.me/themify-icons`")
+              TerminalCommands.open_file_or_link("https://themify.me/themify-icons")
               if font_awesome?
                 TerminalCommands.open_file_or_link("https://fontawesome.com/icons?d=gallery&s=light")
               end

--- a/lib/scaffolding/transformer.rb
+++ b/lib/scaffolding/transformer.rb
@@ -1348,7 +1348,7 @@ class Scaffolding::Transformer
             if `which open`.present?
               TerminalCommands.open_file_or_link("https://themify.me/themify-icons`")
               if font_awesome?
-                TerminalCommands("https://fontawesome.com/icons?d=gallery&s=light")
+                TerminalCommands.open_file_or_link("https://fontawesome.com/icons?d=gallery&s=light")
               end
             else
               puts "Sorry! We can't open these URLs automatically on your platform, but you can visit them manually:"

--- a/lib/scaffolding/transformer.rb
+++ b/lib/scaffolding/transformer.rb
@@ -1346,9 +1346,9 @@ class Scaffolding::Transformer
             puts "OK, great! Let's do this! By default these menu items appear with a puzzle piece, but after you hit enter I'll open two different pages where you can view other icon options. When you find one you like, hover your mouse over it and then come back here and and enter the name of the icon you want to use. (Or hit enter to skip this step.)"
             $stdin.gets.chomp
             if `which open`.present?
-              `open https://themify.me/themify-icons`
+              TerminalCommands.open_file_or_link("https://themify.me/themify-icons`")
               if font_awesome?
-                `open https://fontawesome.com/icons?d=gallery&s=light`
+                TerminalCommands("https://fontawesome.com/icons?d=gallery&s=light")
               end
             else
               puts "Sorry! We can't open these URLs automatically on your platform, but you can visit them manually:"


### PR DESCRIPTION
Closes #4.

### Details
This is similar to [this pull request](https://github.com/bullet-train-co/bullet_train/pull/4) in the main Bullet Train repo, and I pretty much used the same code here as I did in the gem I made [here](https://github.com/gazayas/terminal_commands)

### Another Approach
Since we're trying to use the same `open https://foo.com` command in both here and `bullet_train`, it might benefit us to put the put the gem in `bullet_train` and just use the methods in repositories like this one. I confirmed it worked when making a new app, putting the gem in the Gemfile there, and using `TerminalCommands.open_file_or_link` here without the module I made in this pull request.

The only reason I refrained from making another PR there was because it would be in separate places, which might be confusing. For that reason, I just wrote the logic here. If there's a certain approach you'd like me to take, just let me know. If not, we can just use this module in the meantime.