### PR TITLE
Raise error when attribute type is invalid

### DIFF
--- a/lib/scaffolding.rb
+++ b/lib/scaffolding.rb
@@ -1,2 +1,21 @@
 module Scaffolding
+  def self.valid_attribute_type?(type)
+    [
+      "boolean",
+      "button",
+      "cloudinary_image",
+      "color_picker",
+      "date_and_time_field",
+      "date_field",
+      "email_field",
+      "file_field",
+      "options",
+      "password_field",
+      "phone_field",
+      "super_select",
+      "text_area",
+      "text_field",
+      "trix_editor"
+    ].include?(type)
+  end
 end

--- a/lib/scaffolding/script.rb
+++ b/lib/scaffolding/script.rb
@@ -37,6 +37,12 @@ def check_required_options_for_attributes(scaffolding_type, attributes, child, p
     name = parts.shift
     type = parts.join(":")
 
+    unless Scaffolding.valid_attribute_type?(type)
+      raise "You have entered an invalid attribute type: #{type}. General data types are used when creating new models, but Bullet Train " +
+            "uses field partials when Super Scaffolding, i.e. - `name:text_field` as opposed to `name:string`. " +
+            "Please refer to the Field Partial documentation to view which attribute types are available."
+    end
+
     # extract any options they passed in with the field.
     type, attribute_options = type.scan(/^(.*){(.*)}/).first || type
 

--- a/lib/scaffolding/transformer.rb
+++ b/lib/scaffolding/transformer.rb
@@ -655,8 +655,12 @@ class Scaffolding::Transformer
         "email"
       when "color_picker"
         "code"
-      else
+      when "text_field"
         "text"
+      when "text_area"
+        "text"
+      else
+        raise "Invalid attribute type: #{type}."
       end
 
       cell_attributes = if boolean_buttons

--- a/test/lib/scaffolding/script_test.rb
+++ b/test/lib/scaffolding/script_test.rb
@@ -1,0 +1,14 @@
+require "test_helper"
+require "minitest/spec"
+
+require_relative "../../../lib/scaffolding"
+
+describe "Super Scaffolding Script" do
+  it "returns true when the attribute type is valid" do
+    assert Scaffolding.valid_attribute_type?("boolean")
+  end
+
+  it "raises an error when the attribute type is invalid" do
+    refute Scaffolding.valid_attribute_type?("string")
+  end
+end


### PR DESCRIPTION
・Closes #8.

### Details
We probably don't need the hook in the transformer if we catch the invalid type in `script.rb`, but I figured it would be good to have a safeguard just in case.

Also, I considered putting `valid_attribute_type?` in `script.rb`, but the tests were acting weird so I deferred to putting it in `scaffolding.rb` instead.

### Tests
By the way, here's the output the test was giving when using that method in `script.rb` (the issue was I had `require "scaffolding/script"` written in the test which was running the script unnecessarily):
```
$ bundle exec rails test test/lib/scaffolding/script_test.rb

Invalid scaffolding type "test/lib/scaffolding/script_test.rb".

🚅  usage: bin/super-scaffold [type] (... | --help)

Supported types of scaffolding:

  crud
  crud-field
  join-model
  oauth-provider

Try `bin/super-scaffold [type]` for usage examples.

Run options: --seed 34178

# Running:

..

Finished in 0.003959s, 505.1679 runs/s, 505.1679 assertions/s.
2 runs, 2 assertions, 0 failures, 0 errors, 0 skips
```