### PR TITLE
Super Scaffold color picker with default colors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ aliases:
       paths:
         - node_modules
   - &ruby_node_browsers_docker_image
-      - image: cimg/ruby:3.1.1-browsers
+      - image: cimg/ruby:3.1.2-browsers
         environment:
           PGHOST: localhost
           PGUSER: untitled_application

--- a/app/views/account/scaffolding/completely_concrete/tangible_things/show.html.erb
+++ b/app/views/account/scaffolding/completely_concrete/tangible_things/show.html.erb
@@ -15,6 +15,7 @@
           <%= render 'shared/attributes/boolean', attribute: :boolean_button_value %>
           <%= render 'shared/attributes/option', attribute: :button_value %>
           <%= render 'shared/attributes/options', attribute: :multiple_button_values %>
+          <%= render 'shared/attributes/code', attribute: :color_picker_value %>
           <%= render 'shared/attributes/text', attribute: :cloudinary_image_value %>
           <%= render 'shared/attributes/date', attribute: :date_field_value %>
           <%= render 'shared/attributes/date_and_time', attribute: :date_and_time_field_value %>

--- a/lib/scaffolding/transformer.rb
+++ b/lib/scaffolding/transformer.rb
@@ -798,12 +798,6 @@ class Scaffolding::Transformer
           end
         end
 
-        # `options` itself is usually a hash inside of field_attributes, but we change
-        # it to a String here so it's consistent with the Tangible Things form partial.
-        if type == "color_picker"
-          field_attributes[:options] = "t('#{child.downcase.pluralize}.fields.#{name_without_id}.options')"
-        end
-
         field_content = "<%= render 'shared/fields/#{type}'#{", " if field_attributes.any?}#{field_attributes.map { |key, value| "#{key}: #{value}" }.join(", ")} %>"
 
         # TODO Add more of these from other packages?

--- a/lib/scaffolding/transformer.rb
+++ b/lib/scaffolding/transformer.rb
@@ -798,6 +798,12 @@ class Scaffolding::Transformer
           end
         end
 
+        # `options` itself is usually a hash inside of field_attributes, but we change
+        # it to a String here so it's consistent with the Tangible Things form partial.
+        if type == "color_picker"
+          field_attributes[:options] = "t('#{child.downcase.pluralize}.fields.#{name_without_id}.options')"
+        end
+
         field_content = "<%= render 'shared/fields/#{type}'#{", " if field_attributes.any?}#{field_attributes.map { |key, value| "#{key}: #{value}" }.join(", ")} %>"
 
         # TODO Add more of these from other packages?
@@ -910,6 +916,18 @@ class Scaffolding::Transformer
               two: Two
               three: Three
 
+            <% end %>
+
+            <% if type == "color_picker" %>
+            options:
+              - '#9C73D2'
+              - '#48CDFE'
+              - '#53F3ED'
+              - '#47E37F'
+              - '#F2593D'
+              - '#F68421'
+              - '#F9DE00'
+              - '#929292'
             <% end %>
 
           <% if is_association %>


### PR DESCRIPTION
・Closes #13.

[Joint PR](https://github.com/bullet-train-co/bullet_train/pull/39)

### Details
It turns out we weren't showing the default colors or the hex code in the show view, so I made sure they both show up and that they're tested.

### Can't use a custom name
Currently, we can only use `color_picker_value` for this attribute name. The original partial seems to be in the tailwind repo or somewhere else, so it seems like unless we change that we'll always have to use `color_picker_value` for the attribute name.