### PR TITLE
First pass on testing Super Scaffolded field partials

### DIFF
--- a/lib/scaffolding/transformer.rb
+++ b/lib/scaffolding/transformer.rb
@@ -639,7 +639,7 @@ class Scaffolding::Transformer
         elsif is_id
           "belongs_to"
         else
-          "option"
+          "option#{"s" if is_multiple}"
         end
       when "cloudinary_image"
         attribute_options[:height] = 200
@@ -769,7 +769,7 @@ class Scaffolding::Transformer
         end
 
         if is_multiple
-          field_options[:multiple] = "true"
+          field_attributes[:multiple] = "true"
         end
 
         valid_values = if is_id
@@ -936,7 +936,7 @@ class Scaffolding::Transformer
         [
           "./app/controllers/account/scaffolding/completely_concrete/tangible_things_controller.rb"
         ].each do |file|
-          if is_ids
+          if is_ids || is_multiple
             scaffold_add_line_to_file(file, "#{name}: [],", RUBY_NEW_ARRAYS_HOOK, prepend: true)
           else
             scaffold_add_line_to_file(file, ":#{name},", RUBY_NEW_FIELDS_HOOK, prepend: true)

--- a/lib/scaffolding/transformer.rb
+++ b/lib/scaffolding/transformer.rb
@@ -1137,6 +1137,10 @@ class Scaffolding::Transformer
           scaffold_add_line_to_file("./app/models/scaffolding/completely_concrete/tangible_thing.rb", "has_one_attached :#{name}", HAS_ONE_HOOK, prepend: true)
         when "trix_editor"
           scaffold_add_line_to_file("./app/models/scaffolding/completely_concrete/tangible_thing.rb", "has_rich_text :#{name}", HAS_ONE_HOOK, prepend: true)
+        when "buttons"
+          if boolean_buttons
+            scaffold_add_line_to_file("./app/models/scaffolding/completely_concrete/tangible_thing.rb", "validates :#{name}, inclusion: [true, false]", VALIDATIONS_HOOK, prepend: true)
+          end
         end
 
       end

--- a/lib/scaffolding/transformer.rb
+++ b/lib/scaffolding/transformer.rb
@@ -768,8 +768,14 @@ class Scaffolding::Transformer
           # add_additional_step :yellow, transform_string("We've added a reference to a `placeholder` to the form for the select or super_select field, but unfortunately earlier versions of the scaffolded locales Yaml don't include a reference to `fields: *fields` under `form`. Please add it, otherwise your form won't be able to locate the appropriate placeholder label.")
         end
 
+        # TODO: This feels incorrect.
+        # Should we adjust the partials to only use `{multiple: true}` or `html_options: {multiple_true}`?
         if is_multiple
-          field_attributes[:multiple] = "true"
+          if type == "super_select"
+            field_options[:multiple] = "true"
+          else
+            field_attributes[:multiple] = "true"
+          end
         end
 
         valid_values = if is_id


### PR DESCRIPTION
Closes #14.

[Joint PR](https://github.com/bullet-train-co/bullet_train/pull/49)

### Details
These don't cover all of the partials, but it's a start and there are still some that aren't working properly. The change here was specifically for boolean buttons; before the fix, we were scaffolding `presence: true` which meant the buttons couldn't have a value of `false`. I used this `inclusion` hook to 1. throw an error if it's blank, and 2. accept both `true` and `false` values.

Most of the other fixes are in the Joint PR in the starter repo.
