### PR TITLE
Use `option` attribute partial when scaffolding booleans

### DIFF
--- a/lib/scaffolding/transformer.rb
+++ b/lib/scaffolding/transformer.rb
@@ -631,10 +631,8 @@ class Scaffolding::Transformer
       attribute_partial ||= attribute_options[:attribute] || case type
       when "trix_editor", "ckeditor"
         "html"
-      when "buttons", "super_select", "options"
-        if boolean_buttons
-          "boolean"
-        elsif is_ids
+      when "buttons", "super_select", "options", "boolean"
+        if is_ids
           "has_many"
         elsif is_id
           "belongs_to"

--- a/lib/scaffolding/transformer.rb
+++ b/lib/scaffolding/transformer.rb
@@ -565,7 +565,7 @@ class Scaffolding::Transformer
   def add_attributes_to_various_views(attributes, scaffolding_options = {})
     sql_type_to_field_type_mapping = {
       # 'binary' => '',
-      "boolean" => "buttons",
+      "boolean" => "options",
       "date" => "date_field",
       "datetime" => "date_and_time_field",
       "decimal" => "text_field",


### PR DESCRIPTION
・Closes #18.

### Details
Super Scaffolded `boolean` forms use `shared/fields/buttons` and the index and show views were definitely using `shared/attributes/boolean`, so I made sure booleans are scaffolded as follows:

・In forms → `shared/fields/options`
・In index and show → `shared/attributes/option`

![Screenshot from 2022-04-14 21-43-43](https://user-images.githubusercontent.com/10546292/163393343-4c8e7a56-b672-4885-b444-b8b8c82d7df2.png)

### Testing
I think as long as we have the tests in [this pull request](https://github.com/bullet-train-co/bullet_train/pull/49) in the starter repo, we should be okay with merging this PR. We'll just have to adjust them to select radio buttons as opposed to regular buttons.
