### PR TITLE
Remove CSV imports table

### DIFF
--- a/test/lib/scaffolding/examples/example._rb
+++ b/test/lib/scaffolding/examples/example._rb
@@ -145,23 +145,6 @@ Rails.application.routes.draw do
 
         resources :sites
 
-        namespace :imports do
-          namespace :csv do
-            unless scaffolding_things_disabled?
-              namespace :scaffolding do
-                resources :things_imports do
-                  collection do
-                    get :sample
-                  end
-                  member do
-                    get :rejected_lines
-                  end
-                end
-              end
-            end
-          end
-        end
-
         namespace :oauth do
           resources :stripe_accounts if stripe_enabled?
           resources :twitter_accounts if twitter_enabled?

--- a/test/lib/scaffolding/examples/result_1._rb
+++ b/test/lib/scaffolding/examples/result_1._rb
@@ -145,23 +145,6 @@ Rails.application.routes.draw do
 
         resources :sites
 
-        namespace :imports do
-          namespace :csv do
-            unless scaffolding_things_disabled?
-              namespace :scaffolding do
-                resources :things_imports do
-                  collection do
-                    get :sample
-                  end
-                  member do
-                    get :rejected_lines
-                  end
-                end
-              end
-            end
-          end
-        end
-
         namespace :oauth do
           resources :stripe_accounts if stripe_enabled?
           resources :twitter_accounts if twitter_enabled?

--- a/test/lib/scaffolding/examples/result_2._rb
+++ b/test/lib/scaffolding/examples/result_2._rb
@@ -145,23 +145,6 @@ Rails.application.routes.draw do
 
         resources :sites
 
-        namespace :imports do
-          namespace :csv do
-            unless scaffolding_things_disabled?
-              namespace :scaffolding do
-                resources :things_imports do
-                  collection do
-                    get :sample
-                  end
-                  member do
-                    get :rejected_lines
-                  end
-                end
-              end
-            end
-          end
-        end
-
         namespace :oauth do
           resources :stripe_accounts if stripe_enabled?
           resources :twitter_accounts if twitter_enabled?

--- a/test/lib/scaffolding/examples/result_3._rb
+++ b/test/lib/scaffolding/examples/result_3._rb
@@ -145,23 +145,6 @@ Rails.application.routes.draw do
 
         resources :sites
 
-        namespace :imports do
-          namespace :csv do
-            unless scaffolding_things_disabled?
-              namespace :scaffolding do
-                resources :things_imports do
-                  collection do
-                    get :sample
-                  end
-                  member do
-                    get :rejected_lines
-                  end
-                end
-              end
-            end
-          end
-        end
-
         namespace :oauth do
           resources :stripe_accounts if stripe_enabled?
           resources :twitter_accounts if twitter_enabled?

--- a/test/lib/scaffolding/examples/result_4._rb
+++ b/test/lib/scaffolding/examples/result_4._rb
@@ -145,23 +145,6 @@ Rails.application.routes.draw do
 
         resources :sites
 
-        namespace :imports do
-          namespace :csv do
-            unless scaffolding_things_disabled?
-              namespace :scaffolding do
-                resources :things_imports do
-                  collection do
-                    get :sample
-                  end
-                  member do
-                    get :rejected_lines
-                  end
-                end
-              end
-            end
-          end
-        end
-
         namespace :oauth do
           resources :stripe_accounts if stripe_enabled?
           resources :twitter_accounts if twitter_enabled?

--- a/test/lib/scaffolding/examples/result_5._rb
+++ b/test/lib/scaffolding/examples/result_5._rb
@@ -145,23 +145,6 @@ Rails.application.routes.draw do
 
         resources :sites
 
-        namespace :imports do
-          namespace :csv do
-            unless scaffolding_things_disabled?
-              namespace :scaffolding do
-                resources :things_imports do
-                  collection do
-                    get :sample
-                  end
-                  member do
-                    get :rejected_lines
-                  end
-                end
-              end
-            end
-          end
-        end
-
         namespace :oauth do
           resources :stripe_accounts if stripe_enabled?
           resources :twitter_accounts if twitter_enabled?

--- a/test/lib/scaffolding/examples/result_6._rb
+++ b/test/lib/scaffolding/examples/result_6._rb
@@ -145,23 +145,6 @@ Rails.application.routes.draw do
 
         resources :sites
 
-        namespace :imports do
-          namespace :csv do
-            unless scaffolding_things_disabled?
-              namespace :scaffolding do
-                resources :things_imports do
-                  collection do
-                    get :sample
-                  end
-                  member do
-                    get :rejected_lines
-                  end
-                end
-              end
-            end
-          end
-        end
-
         namespace :oauth do
           resources :stripe_accounts if stripe_enabled?
           resources :twitter_accounts if twitter_enabled?

--- a/test/lib/scaffolding/examples/result_7._rb
+++ b/test/lib/scaffolding/examples/result_7._rb
@@ -145,23 +145,6 @@ Rails.application.routes.draw do
 
         resources :sites
 
-        namespace :imports do
-          namespace :csv do
-            unless scaffolding_things_disabled?
-              namespace :scaffolding do
-                resources :things_imports do
-                  collection do
-                    get :sample
-                  end
-                  member do
-                    get :rejected_lines
-                  end
-                end
-              end
-            end
-          end
-        end
-
         namespace :oauth do
           resources :stripe_accounts if stripe_enabled?
           resources :twitter_accounts if twitter_enabled?

--- a/test/lib/scaffolding/routes_file_manipulator_test.rb
+++ b/test/lib/scaffolding/routes_file_manipulator_test.rb
@@ -91,25 +91,12 @@ describe Scaffolding::RoutesFileManipulator do
         end
       end
     end
-
-    describe "under team" do
-      examples = {
-        ["imports", "csv", "scaffolding"] => {"imports" => 147, "csv" => 148, "scaffolding" => 150}
-      }
-
-      examples.each do |inputs, outputs|
-        it "returns #{outputs} for `#{inputs.first}` under `#{inputs.last}`" do
-          results = subject.new(example_file, nil, nil).find_namespaces(inputs, 143)
-          assert_equal outputs, results
-        end
-      end
-    end
   end
 
   describe "find_block_end" do
     examples = {
       # namespace :account
-      109 => 243
+      109 => 226
     }
 
     examples.each do |starting_line_number, ending_line_number|


### PR DESCRIPTION
Closes [this issue](https://github.com/bullet-train-co/bullet_train/issues/69) in the starter repo.

[Joint PR](https://github.com/bullet-train-co/bullet_train/pull/70)

### Details
The only thing we had to clear out were the tests; the example routes file changed a bit so I deleted the unnecessary lines there, and then adjusted the tests in `test/lib/scaffolding/routes_file_manipulator_test.rb` accordingly.

### SQLite3 Database
Since there's no `config/database.yml` in this repo, running `rails db` commands tries use sqlite3 databases. Since I've already dropped the table over in the starter repo, do we need another migration to drop the table here? The tests are running fine, but if you have a specific direction you want to go in concerning these tables, just let me know and I'll add/delete/edit whatever needs it.