### PR TITLE
Use Ruby 3.1.2 in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ aliases:
       paths:
         - node_modules
   - &ruby_node_browsers_docker_image
-      - image: cimg/ruby:3.1.1-browsers
+      - image: cimg/ruby:3.1.2-browsers
         environment:
           PGHOST: localhost
           PGUSER: untitled_application


### PR DESCRIPTION
Running the starter repo test fails since Ruby has been updated to 3.1.2 in the Gemfile.
For example, it's failing in [this PR](https://github.com/bullet-train-co/bullet_train-super_scaffolding/pull/25).
