### PR TITLE
Scope namespaces to their parent resource in `RoutesFileManipulator`

### DIFF
--- a/bullet_train-super_scaffolding.gemspec
+++ b/bullet_train-super_scaffolding.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "rails", ">= 6.0.0"
   spec.add_dependency "bullet_train"
+  spec.add_dependency "spring"
 
   # For Super Scaffolding: "select *a* team member" vs. "select *an* option".
   spec.add_dependency "indefinite_article"

--- a/lib/scaffolding/block_manipulator.rb
+++ b/lib/scaffolding/block_manipulator.rb
@@ -137,4 +137,8 @@ class Scaffolding::BlockManipulator
     end
     current_line
   end
+
+  def block_indentation_size(line_number)
+    lines[line_number].scan(/^\s+/).first.size
+  end
 end

--- a/lib/scaffolding/routes_file_manipulator.rb
+++ b/lib/scaffolding/routes_file_manipulator.rb
@@ -380,14 +380,14 @@ class Scaffolding::RoutesFileManipulator
       #   resources :deliverables, except: collection_actions
       # end
 
+      # We want to see if there are any namespaces one level above the parent itself,
+      # because namespaces with the same name as the resource can exist on the same level.
+      parent_block_start = find_block_parent(parent_within)
+      namespace_line_within = find_or_create_namespaces(child_namespaces, parent_block_start)
+      find_or_create_resource([child_resource], options: "except: collection_actions", within: namespace_line_within)
       unless find_namespaces(child_namespaces, within)[child_namespaces.last]
-        insert_after(["", "namespace :#{child_namespaces.last} do", "end"], find_block_end(scope_within))
-        unless find_namespaces(child_namespaces, within)[child_namespaces.last]
-          raise "tried to insert `namespace :#{child_namespaces.last}` but it seems we failed"
-        end
+        raise "tried to insert `namespace :#{child_namespaces.last}` but it seems we failed"
       end
-
-      find_or_create_resource(child_namespaces + [child_resource], options: "except: collection_actions", within: within)
 
     # e.g. Projects::Deliverable and Objective Under It, Abstract::Concept and Concrete::Thing
     elsif parent_namespaces.any?
@@ -395,18 +395,16 @@ class Scaffolding::RoutesFileManipulator
       # namespace :projects do
       #   resources :deliverables
       # end
-      #
+      top_parent_namespace = find_namespaces(parent_namespaces, within)[parent_namespaces.first]
+      find_or_create_resource(child_namespaces + [child_resource], within: top_parent_namespace)
+
       # resources :projects_deliverables, path: 'projects/deliverables' do
       #   resources :objectives
       # end
-
-      find_resource(parent_namespaces + [parent_resource], within: within)
-      top_parent_namespace = find_namespaces(parent_namespaces, within)[parent_namespaces.first]
       block_parent_within = find_block_parent(top_parent_namespace)
       parent_namespaces_and_resource = (parent_namespaces + [parent_resource]).join("_")
       parent_within = find_or_create_resource_block([parent_namespaces_and_resource], options: "path: '#{parent_namespaces_and_resource.tr("_", "/")}'", within: block_parent_within)
       find_or_create_resource(child_namespaces + [child_resource], within: parent_within)
-
     else
 
       begin

--- a/lib/scaffolding/routes_file_manipulator.rb
+++ b/lib/scaffolding/routes_file_manipulator.rb
@@ -142,10 +142,10 @@ class Scaffolding::RoutesFileManipulator
     current_namespace = nil
     while namespaces.any?
       current_namespace = namespaces.shift
-      namespace_lines = unless within.nil?
-        scope_namespace_to_parent(current_namespace, within)
-      else
+      namespace_lines = if within.nil?
         find_namespaces(created_namespaces + [current_namespace], within)
+      else
+        scope_namespace_to_parent(current_namespace, within)
       end
 
       unless namespace_lines[current_namespace]

--- a/lib/scaffolding/routes_file_manipulator.rb
+++ b/lib/scaffolding/routes_file_manipulator.rb
@@ -142,7 +142,7 @@ class Scaffolding::RoutesFileManipulator
     current_namespace = nil
     while namespaces.any?
       current_namespace = namespaces.shift
-      namespace_lines = if !within.nil? && namespace_blocks_directly_under_parent(within)
+      namespace_lines = unless within.nil?
         scope_namespace_to_parent(current_namespace, within)
       else
         find_namespaces(created_namespaces + [current_namespace], within)
@@ -189,16 +189,6 @@ class Scaffolding::RoutesFileManipulator
       namespace_line_number if lines[namespace_line_number].match?(/ +namespace :#{namespace}/)
     end.compact
     namespace_block_start.present? ? {namespace => namespace_block_start} : {}
-  end
-
-  def namespace_exists_directly_under_parent?(namespace, within)
-    namespace_blocks_directly_under_parent(within).each do |namespace_block|
-      namespace_line_index = namespace_block.begin - 1
-      if lines[namespace_line_index].match?(/ +namespace :#{namespace}/)
-        return true
-      end
-    end
-    false
   end
 
   def find(needle, within = nil)
@@ -265,7 +255,7 @@ class Scaffolding::RoutesFileManipulator
     result
   end
 
-  # Finds namespace blocks no matter how many levels nested in resource blocks, etc..
+  # Finds namespace blocks no matter how many levels deep they are nested in resource blocks, etc.
   # However, will not find namespace blocks inside namespace blocks.
   def top_level_namespace_block_lines(within)
     local_namespace_blocks = []

--- a/test/lib/scaffolding/examples/result_4._rb
+++ b/test/lib/scaffolding/examples/result_4._rb
@@ -223,13 +223,13 @@ Rails.application.routes.draw do
         scope module: 'teams' do
           resources :logs, only: collection_actions
         end
-
-        namespace :teams do
-          resources :logs, except: collection_actions
-        end
       end
       member do
         post :switch_to
+      end
+
+      namespace :teams do
+        resources :logs, except: collection_actions
       end
     end
   end

--- a/test/lib/scaffolding/examples/result_5._rb
+++ b/test/lib/scaffolding/examples/result_5._rb
@@ -160,6 +160,8 @@ Rails.application.routes.draw do
                 resources :delivery_attempts, only: [:index, :show]
               end
             end
+
+            resources :logs
           end
 
           resources :outgoing_events, path: 'outgoing/events' do


### PR DESCRIPTION
Fixes [#192 in bullet_train-super_scaffolding](https://github.com/bullet-train-co/bullet_train/issues/192).

## Gemfile for the starter repository
```ruby
gem "bullet_train-super_scaffolding", git: "git@github.com:bullet-train-co/bullet_train-super_scaffolding.git", branch: "fixes/scaffold-namespaced-routes-correctly"
```

## The problem
Our current logic for scaffolding namespaces checks if a namespace exists, but since it's possible for multiple namespaces to exist under different resource blocks, new model resource blocks which have a unique namespace hierarchy and should be created from scratch get scaffolded under pre-existing namespaces.

For example, here are some routes we get when Super Scaffolding the following models:
```shell
spring rails g model Insight team:references name:string
spring rails g model Personality::CharacterTrait insight:references name:string

spring rails g model Personality::Disposition team:references name:string
spring rails g model Personality::Note disposition:references name:string
spring rails g model Personality::Observation team:references name:string
spring rails g model Personality::Reactions::Response observation:references name:string
```

### Expected
```ruby
resources :teams do
  resources :insights do
    namespace :personality do
      resources :character_traits
    end
  end

  namespace :personality do
    resources :dispositions do
      resources :notes
    end
    resources :observations do
      namespace :reactions do
        resources :responses
      end
    end
  end
end
```

### Actual
```ruby
resources :teams do
  resources :insights do
    namespace :personality do
      resources :character_traits
      resources :dispositions do
        resources :notes
      end

      resources :observations do
        namespace :reactions do
          resources :responses
        end
      end
    end
  end
end
```


## The fix
Here are the two main methods I implemented to make sure we put the namespaces where they belong:
1. `scope_namespace_to_parent`
2. `namespace_blocks_directly_under_parent`

I tried to document things there clearly, so I won't repeat here to add more unnecessary noise.

## Tests
This will make the Super Scaffolding system test pass except for one test (the `Project::Steps` test on line 195) which doesn't seem to be related to how we scaffold routes. I can look into that as well, but since it seems to be something else (how we scaffold controllers), I thought I'd at least make this pull request first.