### PR TITLE
Refactor `BlockManipulator` and `RoutesFileManipulator`

### DIFF
--- a/lib/scaffolding/block_manipulator.rb
+++ b/lib/scaffolding/block_manipulator.rb
@@ -7,10 +7,10 @@ class Scaffolding::BlockManipulator
   end
 
   #
-  # Wrap a block of ruby code inside another block
+  # Wrap a block of ruby code with another block on the outside.
   #
-  # @param [String] starting A string to search for at the start of the block. Eg "<%= updates_for context, collection do"
-  # @param [Array] with An array with two String elements. The text that should wrap the block. Eg ["<%= action_model_select_controller do %>", "<% end %>"]
+  # @param [String] `starting` A string to search for at the start of the block. Eg "<%= updates_for context, collection do"
+  # @param [Array] `with` An array with two String elements. The text that should wrap the block. Eg ["<%= action_model_select_controller do %>", "<% end %>"]
   #
   def wrap_block(starting:, with:)
     with[0] += "\n" unless with[0].match?(/\n$/)

--- a/lib/scaffolding/block_manipulator.rb
+++ b/lib/scaffolding/block_manipulator.rb
@@ -111,6 +111,18 @@ class Scaffolding::BlockManipulator
     File.write(@filepath, @lines.join)
   end
 
+  def find_block_parent(starting_line_number, lines)
+    return nil unless indentation_of(starting_line_number, lines)
+    cursor = starting_line_number
+    while cursor >= 0
+      unless lines[cursor].match?(/^#{indentation_of(starting_line_number, lines)}/) || !lines[cursor].present?
+        return cursor
+      end
+      cursor -= 1
+    end
+    nil
+  end
+
   def find_block_start(starting_string)
     matcher = Regexp.escape(starting_string)
     starting_line = 0

--- a/lib/scaffolding/block_manipulator.rb
+++ b/lib/scaffolding/block_manipulator.rb
@@ -137,4 +137,13 @@ class Scaffolding::BlockManipulator
     end
     current_line
   end
+
+  # TODO: We shouldn't need this second argument, but since
+  # we have `lines` here and in the RoutesFileManipulator,
+  # the lines diverge from one another when we edit them individually.
+  def indentation_of(line_number, lines)
+    lines[line_number].match(/^( +)/)[1]
+  rescue
+    nil
+  end
 end

--- a/lib/scaffolding/routes_file_manipulator.rb
+++ b/lib/scaffolding/routes_file_manipulator.rb
@@ -269,11 +269,11 @@ class Scaffolding::RoutesFileManipulator
   def namespace_blocks_directly_under_parent(within)
     blocks = []
     if lines[within].match?(/do$/)
-      parent_indentation_size = block_manipulator.block_indentation_size(within)
-      within_block_end = find_block_end(within)
+      parent_indentation_size = block_manipulator.indentation_of(within, lines).length
+      within_block_end = block_manipulator.find_block_end(starting_from: within, lines: lines)
       within.upto(within_block_end) do |line_number|
         if lines[line_number].match?(/^#{" " * (parent_indentation_size + 2)}namespace/)
-          namespace_block_lines = line_number..find_block_end(line_number)
+          namespace_block_lines = line_number..block_manipulator.find_block_end(line_number, lines)
           blocks << namespace_block_lines
         end
       end
@@ -355,7 +355,7 @@ class Scaffolding::RoutesFileManipulator
 
       # We want to see if there are any namespaces one level above the parent itself,
       # because namespaces with the same name as the resource can exist on the same level.
-      parent_block_start = find_block_parent(parent_within)
+      parent_block_start = block_manipulator.find_block_parent(parent_within, lines)
       namespace_line_within = find_or_create_namespaces(child_namespaces, parent_block_start)
       find_or_create_resource([child_resource], options: "except: collection_actions", within: namespace_line_within)
       unless find_namespaces(child_namespaces, within)[child_namespaces.last]

--- a/lib/scaffolding/routes_file_manipulator.rb
+++ b/lib/scaffolding/routes_file_manipulator.rb
@@ -9,11 +9,7 @@ class Scaffolding::RoutesFileManipulator
     @filename = filename
     self.lines = File.readlines(@filename)
     self.transformer_options = transformer_options
-<<<<<<< HEAD
-    self.block_manipulator = Scaffolding::BlockManipulator.new(filename)
-=======
     self.block_manipulator = Scaffolding::BlockManipulator.new(@filename)
->>>>>>> main
   end
 
   def child_parts
@@ -363,14 +359,7 @@ class Scaffolding::RoutesFileManipulator
       namespace_line_within = find_or_create_namespaces(child_namespaces, parent_block_start)
       find_or_create_resource([child_resource], options: "except: collection_actions", within: namespace_line_within)
       unless find_namespaces(child_namespaces, within)[child_namespaces.last]
-<<<<<<< HEAD
-        insert_after(["", "namespace :#{child_namespaces.last} do", "end"], block_manipulator.find_block_end(starting_from: scope_within, lines: lines))
-        unless find_namespaces(child_namespaces, within)[child_namespaces.last]
-          raise "tried to insert `namespace :#{child_namespaces.last}` but it seems we failed"
-        end
-=======
         raise "tried to insert `namespace :#{child_namespaces.last}` but it seems we failed"
->>>>>>> main
       end
 
     # e.g. Projects::Deliverable and Objective Under It, Abstract::Concept and Concrete::Thing
@@ -385,14 +374,7 @@ class Scaffolding::RoutesFileManipulator
       # resources :projects_deliverables, path: 'projects/deliverables' do
       #   resources :objectives
       # end
-<<<<<<< HEAD
-
-      find_resource(parent_namespaces + [parent_resource], within: within)
-      top_parent_namespace = find_namespaces(parent_namespaces, within)[parent_namespaces.first]
       block_parent_within = block_manipulator.find_block_parent(top_parent_namespace, lines)
-=======
-      block_parent_within = find_block_parent(top_parent_namespace)
->>>>>>> main
       parent_namespaces_and_resource = (parent_namespaces + [parent_resource]).join("_")
       parent_within = find_or_create_resource_block([parent_namespaces_and_resource], options: "path: '#{parent_namespaces_and_resource.tr("_", "/")}'", within: block_parent_within)
       find_or_create_resource(child_namespaces + [child_resource], within: parent_within)

--- a/lib/scaffolding/routes_file_manipulator.rb
+++ b/lib/scaffolding/routes_file_manipulator.rb
@@ -82,18 +82,6 @@ class Scaffolding::RoutesFileManipulator
     results
   end
 
-  def find_block_parent(starting_line_number)
-    return nil unless block_manipulator.indentation_of(starting_line_number, lines)
-    cursor = starting_line_number
-    while cursor >= 0
-      unless lines[cursor].match?(/^#{block_manipulator.indentation_of(starting_line_number, lines)}/) || !lines[cursor].present?
-        return cursor
-      end
-      cursor -= 1
-    end
-    nil
-  end
-
   def find_block_end(starting_line_number)
     return nil unless block_manipulator.indentation_of(starting_line_number, lines)
     lines.each_with_index do |line, line_number|
@@ -345,7 +333,7 @@ class Scaffolding::RoutesFileManipulator
 
       find_resource(parent_namespaces + [parent_resource], within: within)
       top_parent_namespace = find_namespaces(parent_namespaces, within)[parent_namespaces.first]
-      block_parent_within = find_block_parent(top_parent_namespace)
+      block_parent_within = block_manipulator.find_block_parent(top_parent_namespace, lines)
       parent_namespaces_and_resource = (parent_namespaces + [parent_resource]).join("_")
       parent_within = find_or_create_resource_block([parent_namespaces_and_resource], options: "path: '#{parent_namespaces_and_resource.tr("_", "/")}'", within: block_parent_within)
       find_or_create_resource(child_namespaces + [child_resource], within: parent_within)

--- a/lib/scaffolding/routes_file_manipulator.rb
+++ b/lib/scaffolding/routes_file_manipulator.rb
@@ -273,7 +273,7 @@ class Scaffolding::RoutesFileManipulator
       within_block_end = block_manipulator.find_block_end(starting_from: within, lines: lines)
       within.upto(within_block_end) do |line_number|
         if lines[line_number].match?(/^#{" " * (parent_indentation_size + 2)}namespace/)
-          namespace_block_lines = line_number..block_manipulator.find_block_end(line_number, lines)
+          namespace_block_lines = line_number..block_manipulator.find_block_end(starting_from: line_number, lines: lines)
           blocks << namespace_block_lines
         end
       end

--- a/test/lib/scaffolding/examples/block_manipulator_data.html.erb
+++ b/test/lib/scaffolding/examples/block_manipulator_data.html.erb
@@ -1,6 +1,3 @@
 
-<% outer_block do %>
-  <% inner_block do %>
-  <% end %>
+<% test_block do %>
 <% end %>
-

--- a/test/lib/scaffolding/examples/block_manipulator_data.html.erb
+++ b/test/lib/scaffolding/examples/block_manipulator_data.html.erb
@@ -1,3 +1,6 @@
 
-<% test_block do %>
+<% outer_block do %>
+  <% inner_block do %>
+  <% end %>
 <% end %>
+

--- a/test/lib/scaffolding/routes_file_manipulator_test.rb
+++ b/test/lib/scaffolding/routes_file_manipulator_test.rb
@@ -101,7 +101,8 @@ describe Scaffolding::RoutesFileManipulator do
 
     examples.each do |starting_line_number, ending_line_number|
       it "returns #{ending_line_number} for #{starting_line_number}" do
-        results = subject.new(example_file, "Something", "Nothing").find_block_end(starting_line_number)
+        results = subject.new(example_file, "Something", "Nothing")
+        results = results.block_manipulator.find_block_end(starting_from: starting_line_number, lines: results.lines)
         assert_equal ending_line_number, results
       end
     end


### PR DESCRIPTION
This is more of an idea than anything and a lot more work could still be done here, but since there's a decent amount of duplicate code between these two files I think this is the direction we should head in.

Although I wrote `lines` in the arguments, I don't like the idea of passing `lines` each time from an external object (I considered using `ObjectSpace.id2ref(lines.id)` so we only handle one object in memory, but it's tricky because `lines` is an array). Since the `BlockManipulator` and `RoutesFileManipulator` each have their own `lines` object, they begin to differ once we start to edit them, so I ended up passing `lines` here just so we're always dealing with the same set of lines.

Anyways, I can do more work on this one, although I think it would be safer if we merged #31 first because our current linear Super Scaffolding tests are failing when trying to scaffold all the namespaces in the tests at once.