### PR TITLE
Add `file_field` to valid attributes, improve valid attribute type check

### DIFF
--- a/lib/scaffolding.rb
+++ b/lib/scaffolding.rb
@@ -16,6 +16,6 @@ module Scaffolding
       "text_area",
       "text_field",
       "trix_editor"
-    ].include?(type)
+    ].include?(type.gsub(/{.*}/, "")) # Pop off curly brackets such as `super_select{class_name=Membership}`
   end
 end

--- a/lib/scaffolding/transformer.rb
+++ b/lib/scaffolding/transformer.rb
@@ -659,6 +659,8 @@ class Scaffolding::Transformer
         "text"
       when "text_area"
         "text"
+      when "file_field"
+        "text"
       else
         raise "Invalid attribute type: #{type}."
       end

--- a/test/lib/scaffolding/script_test.rb
+++ b/test/lib/scaffolding/script_test.rb
@@ -8,7 +8,15 @@ describe "Super Scaffolding Script" do
     assert Scaffolding.valid_attribute_type?("boolean")
   end
 
+  it "returns true when the attribute type is valid with a class name" do
+    assert Scaffolding.valid_attribute_type?("super_select{class_name=Membership}")
+  end
+
   it "raises an error when the attribute type is invalid" do
     refute Scaffolding.valid_attribute_type?("string")
+  end
+
+  it "raises an error when the attribute type is invalid with a class name" do
+    refute Scaffolding.valid_attribute_type?("string{class_name=Membership}")
   end
 end


### PR DESCRIPTION
Fixes #33.

## Details
I sieved through a lot of ideas in the issue's comments, but it really came down to the fact that we hadn't included `file_field` as a valid type, and also that the `valid_attribute_type?` method I implemented didn't compensate for strings with `{class_name=*}` in them.

It was hard to find because there are some parts in Super Scaffolding that don't exit the process or designate the process as failed in CircleCI even if we tell the code to raise an error. The error shows up in the terminal, it just continues with the process as if everything is normal, and the process in CircleCI shows up as green (specifically the Super Scaffolding setup script when we should be expecting an error).
