### PR TITLE
Pass color options when Super Scaffolding a color picker

### DIFF
--- a/app/views/account/scaffolding/completely_concrete/tangible_things/_form.html.erb
+++ b/app/views/account/scaffolding/completely_concrete/tangible_things/_form.html.erb
@@ -17,7 +17,7 @@
       </div>
     </div>
 
-    <%= render 'shared/fields/color_picker', method: :color_picker_value, options: t('scaffolding/completely_concrete/tangible_things.fields.color_picker_value.options') %>
+    <%= render 'shared/fields/color_picker', method: :color_picker_value, options: {color_picker_options: t('scaffolding/completely_concrete/tangible_things.fields.color_picker_value.options')} %>
     <%= render 'shared/fields/cloudinary_image', method: :cloudinary_image_value %>
     <%= render 'shared/fields/date_field', method: :date_field_value %>
     <%= render 'shared/fields/date_and_time_field', method: :date_and_time_field_value %>

--- a/lib/scaffolding/transformer.rb
+++ b/lib/scaffolding/transformer.rb
@@ -775,6 +775,10 @@ class Scaffolding::Transformer
           # add_additional_step :yellow, transform_string("We've added a reference to a `placeholder` to the form for the select or super_select field, but unfortunately earlier versions of the scaffolded locales Yaml don't include a reference to `fields: *fields` under `form`. Please add it, otherwise your form won't be able to locate the appropriate placeholder label.")
         end
 
+        if type == "color_picker"
+          field_options[:color_picker_options] = "t('#{child.pluralize.underscore}.fields.color_picker_value.options')"
+        end
+
         # TODO: This feels incorrect.
         # Should we adjust the partials to only use `{multiple: true}` or `html_options: {multiple_true}`?
         if is_multiple


### PR DESCRIPTION
Only one option was showing up in the color picker in [bullet_train#39](https://github.com/bullet-train-co/bullet_train/pull/39), so this PR makes sure we pass the options to populate the color picker.

[bullet_train-themes-tailwind_css#5](https://github.com/bullet-train-co/bullet_train-themes-tailwind_css/pull/5) needs to be pulled in as well to make this work.

![Screenshot from 2022-06-22 19-21-43](https://user-images.githubusercontent.com/10546292/175006455-5e9bc7e3-5c4e-4010-90fb-31442fc6497e.png)

