### PR TITLE
sortable: use Stimulus controller attributes when scaffolding

### DIFF
--- a/lib/scaffolding/transformer.rb
+++ b/lib/scaffolding/transformer.rb
@@ -1347,7 +1347,7 @@ class Scaffolding::Transformer
       end
 
       unless cli_options["skip-table"]
-        scaffold_replace_line_in_file("./app/views/account/scaffolding/completely_concrete/tangible_things/_index.html.erb", transform_string("<tbody data-reorder=\"<%= url_for [:reorder, :account, context, collection] %>\">"), "<tbody>")
+        scaffold_replace_line_in_file("./app/views/account/scaffolding/completely_concrete/tangible_things/_index.html.erb", transform_string("<tbody data-controller=\"sortable\" data-sortable-reorder-path-value=\"<%= url_for [:reorder, :account, context, collection] %>\">"), "<tbody>")
       end
 
       unless cli_options["skip-controller"]


### PR DESCRIPTION
Requires a new release of bullet_train-sortable with functionality from PR https://github.com/bullet-train-co/bullet_train-sortable/pull/6