### PR TITLE
Use correct name when validating `buttons`

### DIFF
--- a/lib/scaffolding.rb
+++ b/lib/scaffolding.rb
@@ -2,7 +2,7 @@ module Scaffolding
   def self.valid_attribute_type?(type)
     [
       "boolean",
-      "button",
+      "buttons",
       "cloudinary_image",
       "color_picker",
       "date_and_time_field",


### PR DESCRIPTION
Reported here: https://discord.com/channels/836637622432170028/836637623048601633/994618831244894238

## Details
`buttons` should be a valid attribute type, but I wrote `button` instead:
![Screenshot from 2022-07-08 18-26-23](https://user-images.githubusercontent.com/10546292/177962130-2fc77976-fa9a-4fe5-ae15-e031d60c9738.png)

## Tests
We have the following attributes for the `PartialTest` model in the Super Scaffolding system tests in this PR → [bullet_train#49](https://github.com/bullet-train-co/bullet_train/pull/49):
```shell
# In the setup script:
spring rails g model PartialTest team:references \
  ...
  single_button_test:string \
  multiple_buttons_test:jsonb \

bin/super-scaffold crud PartialTest Team \
  ...
  single_button_test:buttons \
  multiple_buttons_test:buttons{multiple} \
```

This will fail if whatever attributes we have there are considered invalid when running the script in this PR. Since [bullet_train#49](https://github.com/bullet-train-co/bullet_train/pull/49) is from a little while back it may have been created before the `valid_attribute_type` logic was added because the last build it had was a passing build. Either way, since the tests there should cover us, I decided to leave the tests in this repository as is.