### PR TITLE
Super Scaffold side bar icons properly

### DIFF
--- a/lib/scaffolding/transformer.rb
+++ b/lib/scaffolding/transformer.rb
@@ -1421,7 +1421,7 @@ class Scaffolding::Transformer
           response = $stdin.gets.chomp
           if response.downcase[0] == "y"
             puts ""
-            puts "OK, great! Let's do this! By default these menu items appear with a puzzle piece,"
+            puts "OK, great! Let's do this! By default these menu items appear with a #{font_awesome? ? "puzzle piece" : "present icon"},"
             puts "but after you hit enter I'll open #{font_awesome? ? "two different pages" : "a page"} where you can view other icon options."
             puts "When you find one you like, hover your mouse over it and then come back here and"
             puts "enter the name of the icon you want to use."
@@ -1445,7 +1445,7 @@ class Scaffolding::Transformer
 
             loop do
               puts "Did you find an icon you wanted to use?"
-              puts "Enter the full CSS class here (e.g. 'ti ti-world'#{" or 'fal fa-puzzle-piece'" if font_awesome?}) or hit enter to just use the puzzle piece:"
+              puts "Enter the full CSS class here (e.g. 'ti ti-world'#{" or 'fal fa-puzzle-piece'" if font_awesome?}) or hit enter to just use the #{font_awesome? ? "puzzle piece" : "present icon"}:"
               icon_name = $stdin.gets.chomp
               unless icon_name.match?(/ti\s.*/) || icon_name.match?(/fal\s.*/) || icon_name.strip.empty?
                 puts ""

--- a/lib/scaffolding/transformer.rb
+++ b/lib/scaffolding/transformer.rb
@@ -1422,7 +1422,7 @@ class Scaffolding::Transformer
             puts ""
             puts "OK, great! Let's do this! By default these menu items appear with a puzzle piece, but after you hit enter I'll open two different pages where you can view other icon options. When you find one you like, hover your mouse over it and then come back here and and enter the name of the icon you want to use. (Or hit enter to skip this step.)"
             $stdin.gets.chomp
-            if `which open`.present?
+            if (TerminalCommands.macosx? && `which open`.present?) || TerminalCommands.linux?
               TerminalCommands.open_file_or_link("https://themify.me/themify-icons")
               if font_awesome?
                 TerminalCommands.open_file_or_link("https://fontawesome.com/icons?d=gallery&s=light")
@@ -1437,8 +1437,17 @@ class Scaffolding::Transformer
               puts ""
             end
             puts ""
-            puts "Did you find an icon you wanted to use? Enter the full CSS class here (e.g. 'ti ti-world'#{" or 'fal fa-puzzle-piece'" if font_awesome?}) or hit enter to just use the puzzle piece:"
-            icon_name = $stdin.gets.chomp
+
+            loop do
+              puts "Did you find an icon you wanted to use? Enter the full CSS class here (e.g. 'ti ti-world'#{" or 'fal fa-puzzle-piece'" if font_awesome?}) or hit enter to just use the puzzle piece:"
+              icon_name = $stdin.gets.chomp
+              unless icon_name.match?(/ti\s.*/) || icon_name.match?(/fal\s.*/) || icon_name.strip.empty?
+                puts ""
+                puts "Please enter the full CSS class or hit enter."
+                next
+              end
+              break
+            end
             puts ""
             unless icon_name.length > 0 || icon_name.downcase == "y"
               icon_name = "fal fa-puzzle-piece ti ti-gift"

--- a/lib/scaffolding/transformer.rb
+++ b/lib/scaffolding/transformer.rb
@@ -1421,7 +1421,7 @@ class Scaffolding::Transformer
           response = $stdin.gets.chomp
           if response.downcase[0] == "y"
             puts ""
-            puts "OK, great! Let's do this! By default these menu items appear with a #{font_awesome? ? "puzzle piece" : "present icon"},"
+            puts "OK, great! Let's do this! By default these menu items appear as a #{font_awesome? ? "puzzle piece" : "gift icon"},"
             puts "but after you hit enter I'll open #{font_awesome? ? "two different pages" : "a page"} where you can view other icon options."
             puts "When you find one you like, hover your mouse over it and then come back here and"
             puts "enter the name of the icon you want to use."
@@ -1445,7 +1445,7 @@ class Scaffolding::Transformer
 
             loop do
               puts "Did you find an icon you wanted to use?"
-              puts "Enter the full CSS class here (e.g. 'ti ti-world'#{" or 'fal fa-puzzle-piece'" if font_awesome?}) or hit enter to just use the #{font_awesome? ? "puzzle piece" : "present icon"}:"
+              puts "Enter the full CSS class here (e.g. 'ti ti-world'#{" or 'fal fa-puzzle-piece'" if font_awesome?}) or hit enter to just use the #{font_awesome? ? "puzzle piece" : "gift icon"}:"
               icon_name = $stdin.gets.chomp
               unless icon_name.match?(/ti\s.*/) || icon_name.match?(/fal\s.*/) || icon_name.strip.empty?
                 puts ""

--- a/lib/scaffolding/transformer.rb
+++ b/lib/scaffolding/transformer.rb
@@ -1416,11 +1416,16 @@ class Scaffolding::Transformer
           icon_name = cli_options["sidebar"]
         else
           puts ""
-          puts "Hey, models that are scoped directly off of a Team (or nothing) are eligible to be added to the sidebar. Do you want to add this resource to the sidebar menu? (y/N)"
+          puts "Hey, models that are scoped directly off of a Team (or nothing) are eligible to be added to the sidebar."
+          puts "Do you want to add this resource to the sidebar menu? (y/N)"
           response = $stdin.gets.chomp
           if response.downcase[0] == "y"
             puts ""
-            puts "OK, great! Let's do this! By default these menu items appear with a puzzle piece, but after you hit enter I'll open two different pages where you can view other icon options. When you find one you like, hover your mouse over it and then come back here and and enter the name of the icon you want to use. (Or hit enter to skip this step.)"
+            puts "OK, great! Let's do this! By default these menu items appear with a puzzle piece,"
+            puts "but after you hit enter I'll open #{font_awesome? ? "two different pages" : "a page"} where you can view other icon options."
+            puts "When you find one you like, hover your mouse over it and then come back here and"
+            puts "enter the name of the icon you want to use."
+            puts "(Or hit enter when choosing to skip this step.)"
             $stdin.gets.chomp
             if (TerminalCommands.macosx? && `which open`.present?) || TerminalCommands.linux?
               TerminalCommands.open_file_or_link("https://themify.me/themify-icons")
@@ -1439,7 +1444,8 @@ class Scaffolding::Transformer
             puts ""
 
             loop do
-              puts "Did you find an icon you wanted to use? Enter the full CSS class here (e.g. 'ti ti-world'#{" or 'fal fa-puzzle-piece'" if font_awesome?}) or hit enter to just use the puzzle piece:"
+              puts "Did you find an icon you wanted to use?"
+              puts "Enter the full CSS class here (e.g. 'ti ti-world'#{" or 'fal fa-puzzle-piece'" if font_awesome?}) or hit enter to just use the puzzle piece:"
               icon_name = $stdin.gets.chomp
               unless icon_name.match?(/ti\s.*/) || icon_name.match?(/fal\s.*/) || icon_name.strip.empty?
                 puts ""


### PR DESCRIPTION
Closes #42.

## Details
The CLI tells the developer to include the full CSS path [here](https://github.com/bullet-train-co/bullet_train-super_scaffolding/blob/4036bbc3b829eca93df3724dd5658da988fac9a5/lib/scaffolding/transformer.rb#L1440):
```ruby
 puts "Did you find an icon you wanted to use? Enter the full CSS class here (e.g. 'ti ti-world'#{" or 'fal fa-puzzle-piece'" if font_awesome?}) or hit enter to just use the puzzle piece:"
```

However, we don't check the developer's input to see if it's prefixed with `ti` or `fal`, so I included that here. I'm not sure if we need it, but it might be helpful if devs accidentally overlook the line when putting in the icon of their choice.

## Minor fixes
Besides that there were a couple of other things that I updated:
1. Themify uses the gift icon as opposed to the puzzle piece, so I made this part dynamic.
2. Only one window is opened when Font Awesome isn't enabled, so I made the message dynamic to reflect this.
3. Linux wasn't opening up the browser windows, so I used `TerminalCommands` to take care of it.
