### PR TITLE
Serialize file fields with `rails_blob_path`

### DIFF
--- a/app/controllers/api/v1/scaffolding/completely_concrete/tangible_things_endpoint.rb
+++ b/app/controllers/api/v1/scaffolding/completely_concrete/tangible_things_endpoint.rb
@@ -16,6 +16,7 @@ class Api::V1::Scaffolding::CompletelyConcrete::TangibleThingsEndpoint < Api::V1
       optional :date_field_value, type: Date, allow_blank: true, desc: Api.heading(:date_field_value)
       optional :date_and_time_field_value, type: DateTime, allow_blank: true, desc: Api.heading(:date_and_time_field_value)
       optional :email_field_value, type: String, allow_blank: true, desc: Api.heading(:email_field_value)
+      optional :file_field_value, type: String, allow_blank: true, desc: Api.heading(:file_field_value)
       optional :password_field_value, type: String, allow_blank: true, desc: Api.heading(:password_field_value)
       optional :phone_field_value, type: String, allow_blank: true, desc: Api.heading(:phone_field_value)
       optional :option_value, type: String, allow_blank: true, desc: Api.heading(:option_value)

--- a/app/serializers/api/v1/scaffolding/completely_concrete/tangible_thing_serializer.rb
+++ b/app/serializers/api/v1/scaffolding/completely_concrete/tangible_thing_serializer.rb
@@ -1,5 +1,6 @@
 class Api::V1::Scaffolding::CompletelyConcrete::TangibleThingSerializer < Api::V1::ApplicationSerializer
   set_type "scaffolding/completely_concrete/tangible_thing"
+  singleton_class.include Rails.application.routes.url_helpers
 
   attributes :id,
     :absolutely_abstract_creative_concept_id,
@@ -12,6 +13,7 @@ class Api::V1::Scaffolding::CompletelyConcrete::TangibleThingSerializer < Api::V
     :date_field_value,
     :date_and_time_field_value,
     :email_field_value,
+    :file_field_value,
     :password_field_value,
     :phone_field_value,
     :option_value,
@@ -24,6 +26,12 @@ class Api::V1::Scaffolding::CompletelyConcrete::TangibleThingSerializer < Api::V
     # 🚅 super scaffolding will insert new fields above this line.
     :created_at,
     :updated_at
+
+  # We can serialize file fields with jsonapi-serializer in the following way.
+  # https://github.com/jsonapi-serializer/jsonapi-serializer/issues/131
+  attribute :file_field_value do |object|
+    rails_blob_path(object.file_field_value, disposition: "attachment", only_path: true) if object.file_field_value.attached?
+  end
 
   belongs_to :absolutely_abstract_creative_concept, serializer: Api::V1::Scaffolding::AbsolutelyAbstract::CreativeConceptSerializer
 end

--- a/app/serializers/api/v1/scaffolding/completely_concrete/tangible_thing_serializer.rb
+++ b/app/serializers/api/v1/scaffolding/completely_concrete/tangible_thing_serializer.rb
@@ -13,7 +13,6 @@ class Api::V1::Scaffolding::CompletelyConcrete::TangibleThingSerializer < Api::V
     :date_field_value,
     :date_and_time_field_value,
     :email_field_value,
-    :file_field_value,
     :password_field_value,
     :phone_field_value,
     :option_value,


### PR DESCRIPTION
Poking around a bit, this should be the proper way to serialize file fields.

Joint PR:
- https://github.com/bullet-train-co/bullet_train/pull/314

There were a couple of comments in https://github.com/jsonapi-serializer/jsonapi-serializer/issues/131 which helped, but if we should be serializing things another way I'd be glad to look deeper into the issue. 

We'll still have to fix the tests when we Super Scaffold file fields, but I'd like to separate the two PRs since they feel like two different tasks.