### PR TITLE
Super Scaffold file field serializers and endpoint tests properly

### DIFF
--- a/app/serializers/api/v1/scaffolding/completely_concrete/tangible_thing_serializer.rb
+++ b/app/serializers/api/v1/scaffolding/completely_concrete/tangible_thing_serializer.rb
@@ -26,13 +26,12 @@ class Api::V1::Scaffolding::CompletelyConcrete::TangibleThingSerializer < Api::V
     :created_at,
     :updated_at
 
-  # 🚅 super scaffolding will insert file-related logic above this line.
-
   # 🚅 skip this section when scaffolding.
   attribute :file_field_value do |object|
     rails_blob_path(object.file_field_value, disposition: "attachment", only_path: true) if object.file_field_value.attached?
   end
   # 🚅 stop any skipping we're doing now.
+  # 🚅 super scaffolding will insert file-related logic above this line.
 
   belongs_to :absolutely_abstract_creative_concept, serializer: Api::V1::Scaffolding::AbsolutelyAbstract::CreativeConceptSerializer
 end

--- a/app/serializers/api/v1/scaffolding/completely_concrete/tangible_thing_serializer.rb
+++ b/app/serializers/api/v1/scaffolding/completely_concrete/tangible_thing_serializer.rb
@@ -1,5 +1,6 @@
 class Api::V1::Scaffolding::CompletelyConcrete::TangibleThingSerializer < Api::V1::ApplicationSerializer
   set_type "scaffolding/completely_concrete/tangible_thing"
+  singleton_class.include Rails.application.routes.url_helpers
 
   attributes :id,
     :absolutely_abstract_creative_concept_id,
@@ -24,6 +25,8 @@ class Api::V1::Scaffolding::CompletelyConcrete::TangibleThingSerializer < Api::V
     # 🚅 super scaffolding will insert new fields above this line.
     :created_at,
     :updated_at
+
+  # 🚅 super scaffolding will insert file-related logic above this line.
 
   belongs_to :absolutely_abstract_creative_concept, serializer: Api::V1::Scaffolding::AbsolutelyAbstract::CreativeConceptSerializer
 end

--- a/lib/scaffolding/transformer.rb
+++ b/lib/scaffolding/transformer.rb
@@ -20,6 +20,7 @@ class Scaffolding::Transformer
   RUBY_NEW_FIELDS_HOOK = "# 🚅 super scaffolding will insert new fields above this line."
   RUBY_ADDITIONAL_NEW_FIELDS_HOOK = "# 🚅 super scaffolding will also insert new fields above this line."
   RUBY_EVEN_MORE_NEW_FIELDS_HOOK = "# 🚅 super scaffolding will additionally insert new fields above this line."
+  RUBY_FILES_HOOK = "# 🚅 super scaffolding will insert file-related logic above this line."
   ENDPOINTS_HOOK = "# 🚅 super scaffolding will mount new endpoints above this line."
   ERB_NEW_FIELDS_HOOK = "<%#{RUBY_NEW_FIELDS_HOOK} %>"
   CONCERNS_HOOK = "# 🚅 add concerns above."
@@ -480,7 +481,7 @@ class Scaffolding::Transformer
       current_parent = working_parents.pop
     end
 
-    setup_lines << current_transformer.transform_string("@tangible_thing = create(:scaffolding_completely_concrete_tangible_thing, #{previous_assignment})")
+    setup_lines << current_transformer.transform_string("@tangible_thing = build(:scaffolding_completely_concrete_tangible_thing, #{previous_assignment})")
 
     setup_lines
   end
@@ -615,7 +616,9 @@ class Scaffolding::Transformer
       is_id = name.match?(/_id$/)
       is_ids = name.match?(/_ids$/)
       # if this is the first attribute of a newly scaffolded model, that field is required.
-      is_required = attribute_options[:required] || (scaffolding_options[:type] == :crud && index == 0)
+      unless type == "file_field"
+        is_required = attribute_options[:required] || (scaffolding_options[:type] == :crud && index == 0)
+      end
       is_vanilla = attribute_options&.key?(:vanilla)
       is_belongs_to = is_id && !is_vanilla
       is_has_many = is_ids && !is_vanilla
@@ -1038,7 +1041,7 @@ class Scaffolding::Transformer
         # TODO The serializers can't handle these `has_rich_text` attributes.
         unless type == "trix_editor"
           scaffold_add_line_to_file("./app/views/account/scaffolding/completely_concrete/tangible_things/_tangible_thing.json.jbuilder", ":#{name},", RUBY_NEW_FIELDS_HOOK, prepend: true, suppress_could_not_find: true)
-          scaffold_add_line_to_file("./app/serializers/api/v1/scaffolding/completely_concrete/tangible_thing_serializer.rb", ":#{name},", RUBY_NEW_FIELDS_HOOK, prepend: true)
+          scaffold_add_line_to_file("./app/serializers/api/v1/scaffolding/completely_concrete/tangible_thing_serializer.rb", ":#{name},", RUBY_NEW_FIELDS_HOOK, prepend: true) unless type == "file_field"
 
           assertion = case type
           when "date_field"
@@ -1047,11 +1050,29 @@ class Scaffolding::Transformer
             "assert_equal DateTime.parse(tangible_thing_data['#{name}']), tangible_thing.#{name}"
           when "file_field"
             # TODO: If we want to use Cloudinary to handle our files, we should make sure we're getting a URL.
-            "assert_equal tangible_thing_data['#{name}']['record']['id'], tangible_thing.#{name}.record.id"
+            "assert tangible_thing_data['#{name}'].match?('foo.txt') unless response.status == 201"
           else
             "assert_equal tangible_thing_data['#{name}'], tangible_thing.#{name}"
           end
           scaffold_add_line_to_file("./test/controllers/api/v1/scaffolding/completely_concrete/tangible_things_endpoint_test.rb", assertion, RUBY_NEW_FIELDS_HOOK, prepend: true)
+        end
+
+        # File fields are handled in a specific way when using the jsonapi-serializer.
+        if type == "file_field"
+          file_name = "./app/serializers/api/v1/scaffolding/completely_concrete/tangible_thing_serializer.rb"
+          content = <<~RUBY
+            attribute :#{name} do |object|
+              rails_blob_path(object.#{name}, disposition: "attachment", only_path: true) if object.#{name}.attached?
+            end
+
+          RUBY
+          hook = RUBY_FILES_HOOK
+          scaffold_add_line_to_file(file_name, content, hook, prepend: true)
+
+          # We also want to make sure we attach the dummy file in the endpoint test on setup
+          file_name = "./test/controllers/api/v1/scaffolding/completely_concrete/tangible_things_endpoint_test.rb"
+          content = "@#{child.underscore}.#{name} = Rack::Test::UploadedFile.new(\"test/support/foo.txt\")"
+          scaffold_add_line_to_file(file_name, content, hook, prepend: true)
         end
 
         # scaffold_add_line_to_file("./test/controllers/api/v1/scaffolding/completely_concrete/tangible_things_controller_test.rb", "assert_equal tangible_thing_attributes['#{name.gsub('_', '-')}'], tangible_thing.#{name}", RUBY_NEW_FIELDS_HOOK, prepend: true)
@@ -1294,15 +1315,6 @@ class Scaffolding::Transformer
       scaffold_replace_line_in_file("./test/factories/scaffolding/completely_concrete/tangible_things.rb", content, "absolutely_abstract_creative_concept { nil }")
 
       add_has_many_association
-
-      # Adds file attachment to factory
-      attributes.each do |attribute|
-        attribute_name, partial_type = attribute.split(":")
-        if partial_type == "file_field"
-          content = "#{attribute_name} { Rack::Test::UploadedFile.new(\"test/support/foo.txt\") }"
-          scaffold_replace_line_in_file("./test/factories/scaffolding/completely_concrete/tangible_things.rb", content, "#{attribute_name} { nil }")
-        end
-      end
 
       if class_names_transformer.belongs_to_needs_class_definition?
         scaffold_replace_line_in_file("./app/models/scaffolding/completely_concrete/tangible_thing.rb", transform_string("belongs_to :absolutely_abstract_creative_concept, class_name: \"Scaffolding::AbsolutelyAbstract::CreativeConcept\"\n"), transform_string("belongs_to :absolutely_abstract_creative_concept\n"))


### PR DESCRIPTION
Closes https://github.com/bullet-train-co/bullet_train/issues/310

Joint PR:
- https://github.com/bullet-train-co/bullet_train/pull/315

## Details
With this PR, we can return a URL for attachments when accessing the API. For example, here is `TestFile` after running the Super Scaffolding system test setup script:
```ruby
{"id"=>31,
 "team_id"=>79,
 "created_at"=>"2022-07-23 05:55:00 UTC",
 "updated_at"=>"2022-07-23 05:55:00 UTC",
 "foo"=>
  "/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBEUT09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--253455b607021a225f0d21652f09526c06439b4a/foo.txt?disposition=attachment"}
```

There are some decisions here (like removing `presence: true` from file fields) which I'd like to hear your opinion on, but I set things up this way since things get a little sticky when working with attachments in tests.