### PR TITLE
Super Scaffold passwords with `text` attribute partials

### DIFF
--- a/lib/scaffolding/transformer.rb
+++ b/lib/scaffolding/transformer.rb
@@ -833,6 +833,10 @@ class Scaffolding::Transformer
           <%= render 'shared/attributes/#{attribute_partial}', attribute: :#{attribute_name} %>
         ERB
 
+        if type == "password_field"
+          field_content.gsub!(/\s%>/, ", options: { password: true } %>")
+        end
+
         scaffold_add_line_to_file("./app/views/account/scaffolding/completely_concrete/tangible_things/show.html.erb", field_content.strip, ERB_NEW_FIELDS_HOOK, prepend: true)
 
       end
@@ -860,6 +864,10 @@ class Scaffolding::Transformer
         field_content = <<-ERB
           <td#{cell_attributes}><%= render 'shared/attributes/#{attribute_partial}', attribute: :#{attribute_name}#{", #{table_cell_options.join(", ")}" if table_cell_options.any?} %></td>
         ERB
+
+        if type == "password_field"
+          field_content.gsub!(/\s%>/, ", options: { password: true } %>")
+        end
 
         unless ["Team", "User"].include?(child)
           scaffold_add_line_to_file("./app/views/account/scaffolding/completely_concrete/tangible_things/_index.html.erb", field_content.strip, ERB_NEW_FIELDS_HOOK, prepend: true)

--- a/lib/scaffolding/transformer.rb
+++ b/lib/scaffolding/transformer.rb
@@ -626,7 +626,7 @@ class Scaffolding::Transformer
       when "file_field"
         "file"
       when "password_field"
-        "string"
+        "text"
       else
         raise "Invalid field type: #{type}."
       end


### PR DESCRIPTION
`test/system/super_scaffolding_partial_test.rb` was failing in the starter repository because we were Super Scaffolding password attributes with the following render call in the `index` and `show` templates:
```erb
<%= render 'shared/attributes/string', attribute: :password_field_value %>
```

However, looking at the [example TangibleThing](https://github.com/bullet-train-co/bullet_train-super_scaffolding/blob/6bf7be3623f458aeb83a30a1ef0bad3d4983ab54/app/views/account/scaffolding/completely_concrete/tangible_things/show.html.erb#L24) in this repository, the attribute partial should be `text`:
```erb
<%= render 'shared/attributes/text', attribute: :password_field_value %>
```

The change to `"text"` in this PR is ultimately set [here](https://github.com/bullet-train-co/bullet_train-super_scaffolding/blob/6bf7be3623f458aeb83a30a1ef0bad3d4983ab54/lib/scaffolding/transformer.rb#L832-L834) in the transformer for the show template, and shortly after for the index template:
```ruby
field_content = <<-ERB
  <%= render 'shared/attributes/#{attribute_partial}', attribute: :#{attribute_name} %>
ERB
```
