### PR TITLE
Super Scaffold strong params for multiple options correctly

### DIFF
--- a/lib/scaffolding/transformer.rb
+++ b/lib/scaffolding/transformer.rb
@@ -960,6 +960,10 @@ class Scaffolding::Transformer
           elsif is_multiple
             "assign_checkboxes(strong_params, :#{name})"
           end
+        when "options"
+          if is_multiple
+            "assign_checkboxes(strong_params, :#{name}"
+          end
         when "super_select"
           if boolean_buttons
             "assign_boolean(strong_params, :#{name})"

--- a/lib/scaffolding/transformer.rb
+++ b/lib/scaffolding/transformer.rb
@@ -962,7 +962,7 @@ class Scaffolding::Transformer
           end
         when "options"
           if is_multiple
-            "assign_checkboxes(strong_params, :#{name}"
+            "assign_checkboxes(strong_params, :#{name})"
           end
         when "super_select"
           if boolean_buttons


### PR DESCRIPTION
Pretty straightforward, just as the title suggests.
The other main fix is in the `bullet_train-themes-tailwind_css` PR below.

Joint PRs
- https://github.com/bullet-train-co/bullet_train-themes-tailwind_css/pull/13
- https://github.com/bullet-train-co/bullet_train/pull/347