### PR TITLE
Modulize the `BlockManipulator`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,5 +21,3 @@ gem "bullet_train-api"
 
 # Start debugger with binding.b [https://github.com/ruby/debug]
 # gem "debug", ">= 1.0.0"
-
-gem "pry"

--- a/Gemfile
+++ b/Gemfile
@@ -21,3 +21,5 @@ gem "bullet_train-api"
 
 # Start debugger with binding.b [https://github.com/ruby/debug]
 # gem "debug", ">= 1.0.0"
+
+gem "pry"

--- a/lib/scaffolding/block_manipulator.rb
+++ b/lib/scaffolding/block_manipulator.rb
@@ -104,11 +104,6 @@ module Scaffolding::BlockManipulator
     lines = insert_line(block_content[1], block_end + 1, lines)
   end
 
-  # TODO: Delete this because it only really needs to be in the FileManipulator
-  def write
-    File.write(@filepath, @lines.join)
-  end
-
   def find_block_parent(starting_line_number, lines)
     return nil unless indentation_of(starting_line_number, lines)
     cursor = starting_line_number

--- a/lib/scaffolding/block_manipulator.rb
+++ b/lib/scaffolding/block_manipulator.rb
@@ -1,27 +1,22 @@
-class Scaffolding::BlockManipulator
-  attr_accessor :lines
+require "scaffolding/file_manipulator"
 
-  def initialize(filepath)
-    @filepath = filepath
-    @lines = File.readlines(filepath)
-  end
-
+module Scaffolding::BlockManipulator
   #
   # Wrap a block of ruby code with another block on the outside.
   #
   # @param [String] `starting` A string to search for at the start of the block. Eg "<%= updates_for context, collection do"
   # @param [Array] `with` An array with two String elements. The text that should wrap the block. Eg ["<%= action_model_select_controller do %>", "<% end %>"]
   #
-  def wrap_block(starting:, with:)
+  def self.wrap_block(starting:, with:, lines:)
     with[0] += "\n" unless with[0].match?(/\n$/)
     with[1] += "\n" unless with[1].match?(/\n$/)
-    starting_line = find_block_start(starting)
-    end_line = find_block_end(starting_from: starting_line, lines: @lines)
+    starting_line = find_block_start(starting_from: starting, lines: lines)
+    end_line = find_block_end(starting_from: starting_line, lines: lines)
 
     final = []
     block_indent = ""
     spacer = "  "
-    @lines.each_with_index do |line, index|
+    lines.each_with_index do |line, index|
       line += "\n" unless line.match?(/\n$/)
       if index < starting_line
         final << line
@@ -39,72 +34,74 @@ class Scaffolding::BlockManipulator
       end
     end
 
-    @lines = final
-    unless @lines.last.match?(/\n$/)
-      @lines.last += "\n"
+    lines = final
+    unless lines.last.match?(/\n$/)
+      lines.last = "#{lines.last}\n"
     end
+    lines
   end
 
-  def insert(content, within: nil, after: nil, before: nil, after_block: nil, append: false)
+  def self.insert(content, within: nil, after: nil, before: nil, after_block: nil, append: false, lines:)
     # Search for before like we do after, we'll just inject before it.
     after ||= before
 
     # If within is given, find the start and end lines of the block
     content += "\n" unless content.match?(/\n$/)
     start_line = 0
-    end_line = @lines.count - 1
+    end_line = lines.count - 1
     if within.present?
-      start_line = find_block_start(within)
-      end_line = find_block_end(starting_from: start_line, lines: @lines)
+      start_line = find_block_start(starting_from: within, lines: lines)
+      end_line = find_block_end(starting_from: start_line, lines: lines)
       # start_line += 1 # ensure we actually insert the content _within_ the given block
       # end_line += 1 if end_line == start_line
     end
     if after_block.present?
-      block_start = find_block_start(after_block)
-      block_end = find_block_end(starting_from: block_start, lines: @lines)
+      block_start = find_block_start(starting_from: after_block, lines: lines)
+      block_end = find_block_end(starting_from: block_start, lines: lines)
       start_line = block_end
-      end_line = @lines.count - 1
+      end_line = lines.count
     end
     index = start_line
     match = false
     while index < end_line && !match
-      line = @lines[index]
+      line = lines[index]
       if after.nil? || line.match?(after)
         unless append
           match = true
           # We adjust the injection point if we really wanted to insert before.
-          insert_line(content, index - (before ? 1 : 0))
+          lines = insert_line(content, index - (before ? 1 : 0), lines)
         end
       end
       index += 1
     end
 
-    return if match
+    return lines if match
 
     # Match should always be false here.
     if append && !match
-      insert_line(content, index - 1)
+      lines = insert_line(content, index - 1, lines)
     end
+    lines
   end
 
-  def insert_line(content, insert_at_index)
+  def self.insert_line(content, insert_at_index, lines)
     content += "\n" unless content.match?(/\n$/)
     final = []
-    @lines.each_with_index do |line, index|
+    lines.each_with_index do |line, index|
       indent = line.match(/^\s*/).to_s
       final << line
       if index == insert_at_index
         final << indent + content
       end
     end
-    @lines = final
+    final
   end
 
-  def insert_block(block_content, after_block:)
-    block_start = find_block_start(after_block)
-    block_end = find_block_end(starting_from: block_start, lines: @lines)
-    insert_line(block_content[0], block_end)
-    insert_line(block_content[1], block_end + 1)
+  def self.insert_block(block_content, after_block:, lines:)
+    block_start = find_block_start(starting_from: after_block, lines: lines)
+    block_end = find_block_end(starting_from: block_start, lines: lines)
+    lines = insert_line(block_content[0], block_end, lines)
+    lines = insert_line(block_content[1], block_end + 1, lines)
   end
 
   # TODO: Delete this because it only really needs to be in the FileManipulator
@@ -124,11 +121,11 @@ class Scaffolding::BlockManipulator
     nil
   end
 
-  def find_block_start(starting_string)
-    matcher = Regexp.escape(starting_string)
+  def self.find_block_start(starting_from:, lines:)
+    matcher = Regexp.escape(starting_from)
     starting_line = 0
 
-    @lines.each_with_index do |line, index|
+    lines.each_with_index do |line, index|
       if line.match?(matcher)
         starting_line = index
         break
@@ -137,7 +134,7 @@ class Scaffolding::BlockManipulator
     starting_line
   end
 
-  def find_block_end(starting_from:, lines:)
+  def self.find_block_end(starting_from:, lines:)
     # This loop was previously in the RoutesFileManipulator.
     lines.each_with_index do |line, line_number|
       next unless line_number > starting_from
@@ -148,7 +145,7 @@ class Scaffolding::BlockManipulator
 
     depth = 0
     current_line = starting_from
-    @lines[starting_from..@lines.count].each_with_index do |line, index|
+    lines[starting_from..lines.count].each_with_index do |line, index|
       current_line = starting_from + index
       depth += 1 if line.match?(/\s*<%.+ do .*%>/)
       depth += 1 if line.match?(/\s*<% if .*%>/)
@@ -159,10 +156,7 @@ class Scaffolding::BlockManipulator
     current_line
   end
 
-  # TODO: We shouldn't need this second argument, but since
-  # we have `lines` here and in the RoutesFileManipulator,
-  # the lines diverge from one another when we edit them individually.
-  def indentation_of(line_number, lines)
+  def self.indentation_of(line_number, lines)
     lines[line_number].match(/^( +)/)[1]
   rescue
     nil

--- a/test/lib/scaffolding/block_manipulator_test.rb
+++ b/test/lib/scaffolding/block_manipulator_test.rb
@@ -5,168 +5,159 @@ require "scaffolding/block_manipulator"
 
 describe Scaffolding::BlockManipulator do
   file_path = "./test/lib/scaffolding/examples/block_manipulator_data.html.erb"
-  initial_file_contents = File.open(file_path).readlines.join
+  initial_file_contents =
+    <<~INITIAL
+      <% test_block do %>
+      <% end %>
+    INITIAL
 
   after :all do
     File.write(file_path, initial_file_contents)
-  end
-
-  it "initializes" do
-    Scaffolding::BlockManipulator.new(file_path)
   end
 
   def initialize_demo_file file_path, data = nil
     File.write(file_path, data)
   end
 
-  it "Inserts within a block and after the given location" do
+  it "inserts within a block and after the given location" do
     initial_data =
       <<~INITIAL
-
         <% test_block do %>
           <p>with some content</p>
         <% end %>
-
       INITIAL
-
     initialize_demo_file(file_path, initial_data)
-    block_manipulator = Scaffolding::BlockManipulator.new(file_path)
-    block_manipulator.insert("a new string", within: "<% test_block", after: "<p>")
-    block_manipulator.write
+
+    initial_lines = File.readlines(file_path)
+    new_lines = Scaffolding::BlockManipulator.insert("a new string", within: "<% test_block", after: "<p>", lines: initial_lines)
+    Scaffolding::FileManipulator.write(file_path, new_lines)
+
     expected_result =
       <<~RESULT
-
         <% test_block do %>
           <p>with some content</p>
           a new string
         <% end %>
-
       RESULT
+    assert_equal(new_lines.join, expected_result)
     assert_equal(File.read(file_path), expected_result)
   end
 
   it "inserts into an empty block" do
     initial_data =
       <<~INITIAL
-
         <% outer_block do %>
           <% inner_block do %>
           <% end %>
         <% end %>
-
       INITIAL
     initialize_demo_file(file_path, initial_data)
-    block_manipulator = Scaffolding::BlockManipulator.new(file_path)
-    block_manipulator.insert("  Some new content", within: "<% inner_block")
-    block_manipulator.write
+
+    initial_lines = File.readlines(file_path)
+    new_lines = Scaffolding::BlockManipulator.insert("  Some new content", within: "<% inner_block", lines: initial_lines)
+    Scaffolding::FileManipulator.write(file_path, new_lines)
+
     expected_result =
       <<~EXPECTED
-
         <% outer_block do %>
           <% inner_block do %>
             Some new content
           <% end %>
         <% end %>
-
       EXPECTED
+    assert_equal(new_lines.join, expected_result)
     assert_equal(File.read(file_path), expected_result)
   end
 
-  it "Inserts content after the given block" do
+  it "inserts content after the given block" do
     initial_data =
       <<~INITIAL
-
         <% outer_block do %>
           <% inner_block do %>
           <% end %>
         <% end %>
-
       INITIAL
     initialize_demo_file(file_path, initial_data)
-    block_manipulator = Scaffolding::BlockManipulator.new(file_path)
-    block_manipulator.insert("Post content", after_block: "<% inner_block")
-    block_manipulator.write
+
+    initial_lines = File.readlines(file_path)
+    new_lines = Scaffolding::BlockManipulator.insert("Post content", after_block: "<% inner_block", lines: initial_lines)
+    Scaffolding::FileManipulator.write(file_path, new_lines)
+
     expected_result =
       <<~EXPECTED
-
         <% outer_block do %>
           <% inner_block do %>
           <% end %>
           Post content
         <% end %>
-
       EXPECTED
+    assert_equal(new_lines.join, expected_result)
     assert_equal(File.read(file_path), expected_result)
   end
 
   it "appends a line after the block" do
     initial_data_state =
       <<~DATA
-
         <% test_block do %>
         <% end %>
-
       DATA
-
     initialize_demo_file(file_path, initial_data_state)
-    block_manipulator = Scaffolding::BlockManipulator.new(file_path)
-    block_manipulator.insert("This is a new line", after_block: "<% test_block")
-    block_manipulator.write
+
+    initial_lines = File.readlines(file_path)
+    new_lines = Scaffolding::BlockManipulator.insert("This is a new line", after_block: "<% test_block", lines: initial_lines)
+    Scaffolding::FileManipulator.write(file_path, new_lines)
+
     expected_result =
       <<~RESULT
-
         <% test_block do %>
         <% end %>
         This is a new line
-
       RESULT
+    assert_equal(new_lines.join, expected_result)
     assert_equal(File.read(file_path), expected_result)
   end
 
-  it "Inserts within an if statement" do
+  it "inserts within an if statement" do
     initial_data =
       <<~INITIAL
-
         <% if a_test %>
           <p>with some content</p>
         <% end %>
-
       INITIAL
-
     initialize_demo_file(file_path, initial_data)
-    block_manipulator = Scaffolding::BlockManipulator.new(file_path)
-    block_manipulator.insert("a new string", within: "<% if a_test", after: "<p>")
-    block_manipulator.write
+
+    initial_lines = File.readlines(file_path)
+    new_lines = Scaffolding::BlockManipulator.insert("a new string", within: "<% if a_test", after: "<p>", lines: initial_lines)
+    Scaffolding::FileManipulator.write(file_path, new_lines)
+
     expected_result =
       <<~RESULT
-
         <% if a_test %>
           <p>with some content</p>
           a new string
         <% end %>
-
       RESULT
+    assert_equal(new_lines.join, expected_result)
     assert_equal(File.read(file_path), expected_result)
   end
 
   it "inserts a new block then adds a line to it" do
     initial_data =
       <<~INITIAL
-
         <% outer_block do %>
           <% inner_block do %>
           <% end %>
         <% end %>
-
       INITIAL
     initialize_demo_file(file_path, initial_data)
-    block_manipulator = Scaffolding::BlockManipulator.new(file_path)
-    block_manipulator.insert_block(["<% new_block do %>", "<% end %>"], after_block: "<% inner_block")
-    block_manipulator.insert("  an inner line", within: "<% new_block")
-    block_manipulator.write
+
+    initial_lines = File.readlines(file_path)
+    lines_with_block = Scaffolding::BlockManipulator.insert_block(["<% new_block do %>", "<% end %>"], after_block: "<% inner_block", lines: initial_lines)
+    new_lines = Scaffolding::BlockManipulator.insert("  an inner line", within: "<% new_block", lines: lines_with_block)
+    Scaffolding::FileManipulator.write(file_path, new_lines)
+
     expected_result =
       <<~EXPECTED
-
         <% outer_block do %>
           <% inner_block do %>
           <% end %>
@@ -174,61 +165,58 @@ describe Scaffolding::BlockManipulator do
             an inner line
           <% end %>
         <% end %>
-
       EXPECTED
+    assert_equal(new_lines.join, expected_result)
     assert_equal(File.read(file_path), expected_result)
   end
 
-  it "Wraps a block with a new block" do
+  it "wraps a block with a new block" do
     initial_data_state =
       <<~DATA
-
         <% test_block do %>
         <% end %>
-
       DATA
-
     initialize_demo_file(file_path, initial_data_state)
-    block_manipulator = Scaffolding::BlockManipulator.new(file_path)
-    block_manipulator.wrap_block(starting: "<% test_block", with: ["<% outer_block do %>", "<% end %>"])
-    block_manipulator.write
+
+    initial_lines = File.readlines(file_path)
+    new_lines = Scaffolding::BlockManipulator.wrap_block(starting: "<% test_block", with: ["<% outer_block do %>", "<% end %>"], lines: initial_lines)
+    Scaffolding::FileManipulator.write(file_path, new_lines)
+
     expected_result =
       <<~RESULT
-
         <% outer_block do %>
           <% test_block do %>
           <% end %>
         <% end %>
-
       RESULT
+    assert_equal(new_lines.join, expected_result)
     assert_equal(File.read(file_path), expected_result)
   end
 
-  it "Wraps a nested block" do
+  it "wraps a nested block" do
     initial_state =
       <<~INITIAL
-
         <% test_block do %>
           <% inner_block do %>
           <% end %>
         <% end %>
-
       INITIAL
+    initialize_demo_file(file_path, initial_state)
+
+    initial_lines = File.readlines(file_path)
+    new_lines = Scaffolding::BlockManipulator.wrap_block(starting: "<% inner_block do", with: ["<% wrapping_block do %>", "<% end %>"], lines: initial_lines)
+    Scaffolding::FileManipulator.write(file_path, new_lines)
+
     expected_result =
       <<~RESULT
-
         <% test_block do %>
           <% wrapping_block do %>
             <% inner_block do %>
             <% end %>
           <% end %>
         <% end %>
-
       RESULT
-    initialize_demo_file(file_path, initial_state)
-    block_manipulator = Scaffolding::BlockManipulator.new(file_path)
-    block_manipulator.wrap_block(starting: "<% inner_block do", with: ["<% wrapping_block do %>", "<% end %>"])
-    block_manipulator.write
+    assert_equal(new_lines.join, expected_result)
     assert_equal(File.read(file_path), expected_result)
   end
 end

--- a/test/lib/scaffolding/examples/block_manipulator_data.html.erb
+++ b/test/lib/scaffolding/examples/block_manipulator_data.html.erb
@@ -1,3 +1,2 @@
-
 <% test_block do %>
 <% end %>


### PR DESCRIPTION
The end goal is to refactor the `RoutesFileManipulator` and use block-related methods in the `BlockManipulator` only, but I might have to work with this one a bit more before it actually works. I adjusted the tests a bit, but I think I need to be adjusting the `BlockManipulator` itself so the output isn't different.

I tried replacing the `block_manipulator` instance variable with `Scaffolding::BlockManipulator` (no change to the actual content of the methods), yet it failed so I'm going to have to revise this portion.