### PR TITLE
Modulize the `BlockManipulator`

### DIFF
--- a/lib/scaffolding/block_manipulator.rb
+++ b/lib/scaffolding/block_manipulator.rb
@@ -41,7 +41,7 @@ module Scaffolding::BlockManipulator
     lines
   end
 
-  def self.insert(content, within: nil, after: nil, before: nil, after_block: nil, append: false, lines:)
+  def self.insert(content, lines:, within: nil, after: nil, before: nil, after_block: nil, append: false)
     # Search for before like we do after, we'll just inject before it.
     after ||= before
 
@@ -81,6 +81,7 @@ module Scaffolding::BlockManipulator
     if append && !match
       lines = insert_line(content, index - 1, lines)
     end
+    lines
   end
 
   def self.insert_line(content, insert_at_index, lines)
@@ -100,7 +101,7 @@ module Scaffolding::BlockManipulator
     block_start = find_block_start(starting_from: after_block, lines: lines)
     block_end = find_block_end(starting_from: block_start, lines: lines)
     lines = insert_line(block_content[0], block_end, lines)
-    lines = insert_line(block_content[1], block_end + 1, lines)
+    insert_line(block_content[1], block_end + 1, lines)
   end
 
   def self.find_block_parent(starting_line_number, lines)

--- a/lib/scaffolding/block_manipulator.rb
+++ b/lib/scaffolding/block_manipulator.rb
@@ -108,7 +108,7 @@ module Scaffolding::BlockManipulator
     File.write(file_path, lines.join)
   end
 
-  def find_block_parent(starting_line_number, lines)
+  def self.find_block_parent(starting_line_number, lines)
     return nil unless indentation_of(starting_line_number, lines)
     cursor = starting_line_number
     while cursor >= 0

--- a/lib/scaffolding/block_manipulator.rb
+++ b/lib/scaffolding/block_manipulator.rb
@@ -103,11 +103,6 @@ module Scaffolding::BlockManipulator
     lines = insert_line(block_content[1], block_end + 1, lines)
   end
 
-  # TODO: Delete this because it only really needs to be in the FileManipulator
-  def write(file_path, lines)
-    File.write(file_path, lines.join)
-  end
-
   def self.find_block_parent(starting_line_number, lines)
     return nil unless indentation_of(starting_line_number, lines)
     cursor = starting_line_number

--- a/lib/scaffolding/block_manipulator.rb
+++ b/lib/scaffolding/block_manipulator.rb
@@ -1,27 +1,22 @@
-class Scaffolding::BlockManipulator
-  attr_accessor :lines
+require "scaffolding/file_manipulator"
 
-  def initialize(filepath)
-    @filepath = filepath
-    @lines = File.readlines(filepath)
-  end
-
+module Scaffolding::BlockManipulator
   #
   # Wrap a block of ruby code with another block on the outside.
   #
   # @param [String] `starting` A string to search for at the start of the block. Eg "<%= updates_for context, collection do"
   # @param [Array] `with` An array with two String elements. The text that should wrap the block. Eg ["<%= action_model_select_controller do %>", "<% end %>"]
   #
-  def wrap_block(starting:, with:)
+  def self.wrap_block(starting:, with:, lines:)
     with[0] += "\n" unless with[0].match?(/\n$/)
     with[1] += "\n" unless with[1].match?(/\n$/)
-    starting_line = find_block_start(starting)
-    end_line = find_block_end(starting_from: starting_line, lines: @lines)
+    starting_line = find_block_start(starting_from: starting, lines: lines)
+    end_line = find_block_end(starting_from: starting_line, lines: lines)
 
     final = []
     block_indent = ""
     spacer = "  "
-    @lines.each_with_index do |line, index|
+    lines.each_with_index do |line, index|
       line += "\n" unless line.match?(/\n$/)
       if index < starting_line
         final << line
@@ -39,77 +34,78 @@ class Scaffolding::BlockManipulator
       end
     end
 
-    @lines = final
-    unless @lines.last.match?(/\n$/)
-      @lines.last += "\n"
+    lines = final
+    unless lines.last.match?(/\n$/)
+      lines[-1] += "\n"
     end
+    lines
   end
 
-  def insert(content, within: nil, after: nil, before: nil, after_block: nil, append: false)
+  def self.insert(content, within: nil, after: nil, before: nil, after_block: nil, append: false, lines:)
     # Search for before like we do after, we'll just inject before it.
     after ||= before
 
     # If within is given, find the start and end lines of the block
     content += "\n" unless content.match?(/\n$/)
     start_line = 0
-    end_line = @lines.count - 1
+    end_line = lines.count - 1
     if within.present?
-      start_line = find_block_start(within)
-      end_line = find_block_end(starting_from: start_line, lines: @lines)
+      start_line = find_block_start(starting_from: within, lines: lines)
+      end_line = find_block_end(starting_from: start_line, lines: lines)
       # start_line += 1 # ensure we actually insert the content _within_ the given block
       # end_line += 1 if end_line == start_line
     end
     if after_block.present?
-      block_start = find_block_start(after_block)
-      block_end = find_block_end(starting_from: block_start, lines: @lines)
+      block_start = find_block_start(starting_from: after_block, lines: lines)
+      block_end = find_block_end(starting_from: block_start, lines: lines)
       start_line = block_end
-      end_line = @lines.count - 1
+      end_line = lines.count - 1
     end
     index = start_line
     match = false
     while index < end_line && !match
-      line = @lines[index]
+      line = lines[index]
       if after.nil? || line.match?(after)
         unless append
           match = true
           # We adjust the injection point if we really wanted to insert before.
-          insert_line(content, index - (before ? 1 : 0))
+          lines = insert_line(content, index - (before ? 1 : 0), lines)
         end
       end
       index += 1
     end
 
-    return if match
+    return lines if match
 
     # Match should always be false here.
     if append && !match
-      insert_line(content, index - 1)
+      lines = insert_line(content, index - 1, lines)
     end
   end
 
-  def insert_line(content, insert_at_index)
+  def self.insert_line(content, insert_at_index, lines)
     content += "\n" unless content.match?(/\n$/)
     final = []
-    @lines.each_with_index do |line, index|
+    lines.each_with_index do |line, index|
       indent = line.match(/^\s*/).to_s
       final << line
       if index == insert_at_index
         final << indent + content
       end
     end
-    @lines = final
+    final
   end
 
-  def insert_block(block_content, after_block:)
-    block_start = find_block_start(after_block)
-    block_end = find_block_end(starting_from: block_start, lines: @lines)
-    insert_line(block_content[0], block_end)
-    insert_line(block_content[1], block_end + 1)
+  def self.insert_block(block_content, after_block:, lines:)
+    block_start = find_block_start(starting_from: after_block, lines: lines)
+    block_end = find_block_end(starting_from: block_start, lines: lines)
+    lines = insert_line(block_content[0], block_end, lines)
+    lines = insert_line(block_content[1], block_end + 1, lines)
   end
 
   # TODO: Delete this because it only really needs to be in the FileManipulator
-  def write
-    File.write(@filepath, @lines.join)
+  def write(file_path, lines)
+    File.write(file_path, lines.join)
   end
 
   def find_block_parent(starting_line_number, lines)
@@ -124,11 +120,11 @@ class Scaffolding::BlockManipulator
     nil
   end
 
-  def find_block_start(starting_string)
-    matcher = Regexp.escape(starting_string)
+  def self.find_block_start(starting_from:, lines:)
+    matcher = Regexp.escape(starting_from)
     starting_line = 0
 
-    @lines.each_with_index do |line, index|
+    lines.each_with_index do |line, index|
       if line.match?(matcher)
         starting_line = index
         break
@@ -137,7 +133,7 @@ class Scaffolding::BlockManipulator
     starting_line
   end
 
-  def find_block_end(starting_from:, lines:)
+  def self.find_block_end(starting_from:, lines:)
     # This loop was previously in the RoutesFileManipulator.
     lines.each_with_index do |line, line_number|
       next unless line_number > starting_from
@@ -148,7 +144,7 @@ class Scaffolding::BlockManipulator
 
     depth = 0
     current_line = starting_from
-    @lines[starting_from..@lines.count].each_with_index do |line, index|
+    lines[starting_from..lines.count].each_with_index do |line, index|
       current_line = starting_from + index
       depth += 1 if line.match?(/\s*<%.+ do .*%>/)
       depth += 1 if line.match?(/\s*<% if .*%>/)
@@ -162,7 +158,7 @@ class Scaffolding::BlockManipulator
   # TODO: We shouldn't need this second argument, but since
   # we have `lines` here and in the RoutesFileManipulator,
   # the lines diverge from one another when we edit them individually.
-  def indentation_of(line_number, lines)
+  def self.indentation_of(line_number, lines)
     lines[line_number].match(/^( +)/)[1]
   rescue
     nil

--- a/lib/scaffolding/file_manipulator.rb
+++ b/lib/scaffolding/file_manipulator.rb
@@ -62,10 +62,14 @@ module Scaffolding::FileManipulator
     File.write(file, new_lines.join)
   end
 
-  def self.write(file_name, lines)
+  def self.write(file_name, lines, strip: true)
     puts "Updating '#{file_name}'."
-    File.open(file_name, "w+") do |file|
-      file.puts(lines.join.strip + "\n")
+    if strip
+      File.open(file_name, "w+") do |file|
+        file.puts(lines.join.strip + "\n")
+      end
+    else
+      File.write(file_name, lines.join)
     end
   end
 end

--- a/lib/scaffolding/file_manipulator.rb
+++ b/lib/scaffolding/file_manipulator.rb
@@ -3,18 +3,16 @@ require "scaffolding/block_manipulator"
 # TODO: If we move this and the BlockManipulator into their own gems,
 # we can probably call these methods with something shorter without `Scaffolding::`.
 module Scaffolding::FileManipulator
-  # TODO: The block_manipulator shouldn't be an instance variable.
-  def self.find(lines, needle, within = nil, block_manipulator)
-    lines_within(lines, within, block_manipulator).each_with_index do |line, line_number|
+  def self.find(lines, needle, within = nil)
+    lines_within(lines, within).each_with_index do |line, line_number|
       return (within + (within ? 1 : 0) + line_number) if line.match?(needle)
     end
     nil
   end
 
-  # TODO: The block_manipulator shouldn't be an instance variable.
-  def self.lines_within(lines, within, block_manipulator)
+  def self.lines_within(lines, within)
     return lines unless within
-    lines[(within + 1)..(block_manipulator.find_block_end(starting_from: within, lines: lines) + 1)]
+    lines[(within + 1)..(Scaffolding::BlockManipulator.find_block_end(starting_from: within, lines: lines) + 1)]
   end
 
   def self.replace_line_in_file(file, content, in_place_of)

--- a/lib/scaffolding/routes_file_manipulator.rb
+++ b/lib/scaffolding/routes_file_manipulator.rb
@@ -1,7 +1,7 @@
 require "scaffolding/block_manipulator"
 
 class Scaffolding::RoutesFileManipulator
-  attr_accessor :child, :parent, :lines, :transformer_options, :block_manipulator
+  attr_accessor :child, :parent, :lines, :transformer_options
 
   def initialize(filename, child, parent, transformer_options = {})
     self.child = child
@@ -9,7 +9,6 @@ class Scaffolding::RoutesFileManipulator
     @filename = filename
     self.lines = File.readlines(@filename)
     self.transformer_options = transformer_options
-    self.block_manipulator = Scaffolding::BlockManipulator.new(@filename)
   end
 
   def child_parts
@@ -68,7 +67,7 @@ class Scaffolding::RoutesFileManipulator
   def find_namespaces(namespaces, within = nil)
     namespaces = namespaces.dup
     results = {}
-    block_end = block_manipulator.find_block_end(starting_from: within, lines: lines) if within
+    block_end = Scaffolding::BlockManipulator.find_block_end(starting_from: within, lines: lines) if within
     lines.each_with_index do |line, line_number|
       if within
         next unless line_number > within
@@ -86,7 +85,7 @@ class Scaffolding::RoutesFileManipulator
   def insert_before(new_lines, line_number, options = {})
     options[:indent] ||= false
     before = lines[0..(line_number - 1)]
-    new_lines = new_lines.map { |line| (block_manipulator.indentation_of(line_number, lines) + (options[:indent] ? "  " : "") + line).gsub(/\s+$/, "") + "\n" }
+    new_lines = new_lines.map { |line| (Scaffolding::BlockManipulator.indentation_of(line_number, lines) + (options[:indent] ? "  " : "") + line).gsub(/\s+$/, "") + "\n" }
     after = lines[line_number..]
     self.lines = before + (options[:prepend_newline] ? ["\n"] : []) + new_lines + after
   end
@@ -95,7 +94,7 @@ class Scaffolding::RoutesFileManipulator
   def insert_after(new_lines, line_number, options = {})
     options[:indent] ||= false
     before = lines[0..line_number]
-    new_lines = new_lines.map { |line| (block_manipulator.indentation_of(line_number, lines) + (options[:indent] ? "  " : "") + line).gsub(/\s+$/, "") + "\n" }
+    new_lines = new_lines.map { |line| (Scaffolding::BlockManipulator.indentation_of(line_number, lines) + (options[:indent] ? "  " : "") + line).gsub(/\s+$/, "") + "\n" }
     after = lines[(line_number + 1)..]
     self.lines = before + new_lines + (options[:append_newline] ? ["\n"] : []) + after
   end
@@ -104,7 +103,7 @@ class Scaffolding::RoutesFileManipulator
     namespace_lines = find_namespaces(namespaces, within)
     if namespace_lines[namespaces.last]
       block_start = namespace_lines[namespaces.last]
-      insertion_point = block_manipulator.find_block_end(starting_from: block_start, lines: lines)
+      insertion_point = Scaffolding::BlockManipulator.find_block_end(starting_from: block_start, lines: lines)
       insert_before(new_lines, insertion_point, indent: true, prepend_newline: (insertion_point > block_start + 1))
     else
       raise "we weren't able to insert the following lines into the namespace block for #{namespaces.join(" -> ")}:\n\n#{new_lines.join("\n")}"
@@ -172,7 +171,7 @@ class Scaffolding::RoutesFileManipulator
       within = namespace_lines[namespaces.last]
     end
 
-    Scaffolding::FileManipulator.lines_within(lines, within, block_manipulator).each_with_index do |line, line_number|
+    Scaffolding::FileManipulator.lines_within(lines, within).each_with_index do |line, line_number|
       # + 2 because line_number starts from 0, and within starts one line after
       actual_line_number = (within + line_number + 2)
 
@@ -226,7 +225,7 @@ class Scaffolding::RoutesFileManipulator
   # However, will not find namespace blocks inside namespace blocks.
   def top_level_namespace_block_lines(within)
     local_namespace_blocks = []
-    Scaffolding::FileManipulator.lines_within(lines, within, block_manipulator).each do |line|
+    Scaffolding::FileManipulator.lines_within(lines, within).each do |line|
       # i.e. - Retrieve "foo" from "namespace :foo do"
       match_data = line.match(/(\s*namespace\s:)(.*)(\sdo$)/)
 
@@ -236,7 +235,7 @@ class Scaffolding::RoutesFileManipulator
         namespace_name = match_data[2]
         local_namespace = find_namespaces([namespace_name], within)
         starting_line_number = local_namespace[namespace_name]
-        local_namespace_block = ((starting_line_number + 1)..(block_manipulator.find_block_end(starting_from: starting_line_number, lines: lines) + 1))
+        local_namespace_block = ((starting_line_number + 1)..(Scaffolding::BlockManipulator.find_block_end(starting_from: starting_line_number, lines: lines) + 1))
 
         if local_namespace_blocks.empty?
           local_namespace_blocks << local_namespace_block
@@ -263,11 +262,11 @@ class Scaffolding::RoutesFileManipulator
   def namespace_blocks_directly_under_parent(within)
     blocks = []
     if lines[within].match?(/do$/)
-      parent_indentation_size = block_manipulator.indentation_of(within, lines).length
-      within_block_end = block_manipulator.find_block_end(starting_from: within, lines: lines)
+      parent_indentation_size = Scaffolding::BlockManipulator.indentation_of(within, lines).length
+      within_block_end = Scaffolding::BlockManipulator.find_block_end(starting_from: within, lines: lines)
       within.upto(within_block_end) do |line_number|
         if lines[line_number].match?(/^#{" " * (parent_indentation_size + 2)}namespace/)
-          namespace_block_lines = line_number..block_manipulator.find_block_end(starting_from: line_number, lines: lines)
+          namespace_block_lines = line_number..Scaffolding::BlockManipulator.find_block_end(starting_from: line_number, lines: lines)
           blocks << namespace_block_lines
         end
       end
@@ -301,7 +300,7 @@ class Scaffolding::RoutesFileManipulator
 
   # TODO: Remove this and use the BlockManipulator
   def insert(lines_to_add, within)
-    insertion_line = block_manipulator.find_block_end(starting_from: within, lines: lines)
+    insertion_line = Scaffolding::BlockManipulator.find_block_end(starting_from: within, lines: lines)
     result_line = insertion_line
     unless insertion_line == within + 1
       # only put the extra space if we're adding this line after a block
@@ -333,7 +332,7 @@ class Scaffolding::RoutesFileManipulator
       # add the new resource within that namespace.
       line = "scope module: '#{parent_resource}' do"
       # TODO you haven't tested this yet.
-      unless (scope_within = Scaffolding::FileManipulator.find(lines, /#{line}/, parent_within, block_manipulator))
+      unless (scope_within = Scaffolding::FileManipulator.find(lines, /#{line}/, parent_within))
         scope_within = insert([line, "end"], parent_within)
       end
 
@@ -345,7 +344,7 @@ class Scaffolding::RoutesFileManipulator
 
       # We want to see if there are any namespaces one level above the parent itself,
       # because namespaces with the same name as the resource can exist on the same level.
-      parent_block_start = block_manipulator.find_block_parent(parent_within, lines)
+      parent_block_start = Scaffolding::BlockManipulator.find_block_parent(parent_within, lines)
       namespace_line_within = find_or_create_namespaces(child_namespaces, parent_block_start)
       find_or_create_resource([child_resource], options: "except: collection_actions", within: namespace_line_within)
       unless find_namespaces(child_namespaces, within)[child_namespaces.last]
@@ -364,7 +363,7 @@ class Scaffolding::RoutesFileManipulator
       # resources :projects_deliverables, path: 'projects/deliverables' do
       #   resources :objectives
       # end
-      block_parent_within = block_manipulator.find_block_parent(top_parent_namespace, lines)
+      block_parent_within = Scaffolding::BlockManipulator.find_block_parent(top_parent_namespace, lines)
       parent_namespaces_and_resource = (parent_namespaces + [parent_resource]).join("_")
       parent_within = find_or_create_resource_block([parent_namespaces_and_resource], options: "path: '#{parent_namespaces_and_resource.tr("_", "/")}'", within: block_parent_within)
       find_or_create_resource(child_namespaces + [child_resource], within: parent_within)

--- a/test/lib/scaffolding/block_manipulator_test.rb
+++ b/test/lib/scaffolding/block_manipulator_test.rb
@@ -21,7 +21,7 @@ describe Scaffolding::BlockManipulator do
     File.write(file_path, data)
   end
 
-  it "Inserts within a block and after the given location" do
+  it "inserts within a block and after the given location" do
     initial_data =
       <<~INITIAL
 
@@ -79,7 +79,7 @@ describe Scaffolding::BlockManipulator do
     assert_equal(File.read(file_path), expected_result)
   end
 
-  it "Inserts content after the given block" do
+  it "inserts content after the given block" do
     initial_data =
       <<~INITIAL
 
@@ -135,7 +135,7 @@ describe Scaffolding::BlockManipulator do
     assert_equal(File.read(file_path), expected_result)
   end
 
-  it "Inserts within an if statement" do
+  it "inserts within an if statement" do
     initial_data =
       <<~INITIAL
 
@@ -196,7 +196,7 @@ describe Scaffolding::BlockManipulator do
     assert_equal(File.read(file_path), expected_result)
   end
 
-  it "Wraps a block with a new block" do
+  it "wraps a block with a new block" do
     initial_data =
       <<~DATA
 
@@ -223,7 +223,7 @@ describe Scaffolding::BlockManipulator do
     assert_equal(File.read(file_path), expected_result)
   end
 
-  it "Wraps a nested block" do
+  it "wraps a nested block" do
     initial_data =
       <<~INITIAL
 

--- a/test/lib/scaffolding/block_manipulator_test.rb
+++ b/test/lib/scaffolding/block_manipulator_test.rb
@@ -5,14 +5,16 @@ require "scaffolding/block_manipulator"
 
 describe Scaffolding::BlockManipulator do
   file_path = "./test/lib/scaffolding/examples/block_manipulator_data.html.erb"
-  initial_file_contents = File.open(file_path).readlines.join
+  initial_file_contents =
+    <<~INITIAL
+
+      <% test_block do %>
+        <p>with some content</p>
+      <% end %>
+    INITIAL
 
   after :all do
     File.write(file_path, initial_file_contents)
-  end
-
-  it "initializes" do
-    Scaffolding::BlockManipulator.new(file_path)
   end
 
   def initialize_demo_file file_path, data = nil
@@ -28,11 +30,12 @@ describe Scaffolding::BlockManipulator do
         <% end %>
 
       INITIAL
-
     initialize_demo_file(file_path, initial_data)
-    block_manipulator = Scaffolding::BlockManipulator.new(file_path)
-    block_manipulator.insert("a new string", within: "<% test_block", after: "<p>")
-    block_manipulator.write
+    initial_lines = File.readlines(file_path)
+
+    new_lines = Scaffolding::BlockManipulator.insert("a new string", within: "<% test_block", after: "<p>", lines: initial_lines)
+    Scaffolding::FileManipulator.write(file_path, new_lines, strip: false)
+
     expected_result =
       <<~RESULT
 
@@ -42,6 +45,7 @@ describe Scaffolding::BlockManipulator do
         <% end %>
 
       RESULT
+    assert_equal(File.readlines(file_path), new_lines)
     assert_equal(File.read(file_path), expected_result)
   end
 
@@ -56,9 +60,11 @@ describe Scaffolding::BlockManipulator do
 
       INITIAL
     initialize_demo_file(file_path, initial_data)
-    block_manipulator = Scaffolding::BlockManipulator.new(file_path)
-    block_manipulator.insert("  Some new content", within: "<% inner_block")
-    block_manipulator.write
+    initial_lines = File.readlines(file_path)
+
+    new_lines = Scaffolding::BlockManipulator.insert("  Some new content", within: "<% inner_block", lines: initial_lines)
+    Scaffolding::FileManipulator.write(file_path, new_lines, strip: false)
+
     expected_result =
       <<~EXPECTED
 
@@ -69,6 +75,7 @@ describe Scaffolding::BlockManipulator do
         <% end %>
 
       EXPECTED
+    assert_equal(File.readlines(file_path), new_lines)
     assert_equal(File.read(file_path), expected_result)
   end
 
@@ -83,9 +90,11 @@ describe Scaffolding::BlockManipulator do
 
       INITIAL
     initialize_demo_file(file_path, initial_data)
-    block_manipulator = Scaffolding::BlockManipulator.new(file_path)
-    block_manipulator.insert("Post content", after_block: "<% inner_block")
-    block_manipulator.write
+    initial_lines = File.readlines(file_path)
+
+    new_lines = Scaffolding::BlockManipulator.insert("Post content", after_block: "<% inner_block", lines: initial_lines)
+    Scaffolding::FileManipulator.write(file_path, new_lines, strip: false)
+
     expected_result =
       <<~EXPECTED
 
@@ -96,22 +105,24 @@ describe Scaffolding::BlockManipulator do
         <% end %>
 
       EXPECTED
+    assert_equal(File.readlines(file_path), new_lines)
     assert_equal(File.read(file_path), expected_result)
   end
 
   it "appends a line after the block" do
-    initial_data_state =
+    initial_data =
       <<~DATA
 
         <% test_block do %>
         <% end %>
 
       DATA
+    initialize_demo_file(file_path, initial_data)
+    initial_lines = File.readlines(file_path)
 
-    initialize_demo_file(file_path, initial_data_state)
-    block_manipulator = Scaffolding::BlockManipulator.new(file_path)
-    block_manipulator.insert("This is a new line", after_block: "<% test_block")
-    block_manipulator.write
+    new_lines = Scaffolding::BlockManipulator.insert("This is a new line", after_block: "<% test_block", lines: initial_lines)
+    Scaffolding::FileManipulator.write(file_path, new_lines, strip: false)
+
     expected_result =
       <<~RESULT
 
@@ -120,6 +131,7 @@ describe Scaffolding::BlockManipulator do
         This is a new line
 
       RESULT
+    assert_equal(File.readlines(file_path), new_lines)
     assert_equal(File.read(file_path), expected_result)
   end
 
@@ -132,11 +144,12 @@ describe Scaffolding::BlockManipulator do
         <% end %>
 
       INITIAL
-
     initialize_demo_file(file_path, initial_data)
-    block_manipulator = Scaffolding::BlockManipulator.new(file_path)
-    block_manipulator.insert("a new string", within: "<% if a_test", after: "<p>")
-    block_manipulator.write
+    initial_lines = File.readlines(file_path)
+
+    new_lines = Scaffolding::BlockManipulator.insert("a new string", within: "<% if a_test", after: "<p>", lines: initial_lines)
+    Scaffolding::FileManipulator.write(file_path, new_lines, strip: false)
+
     expected_result =
       <<~RESULT
 
@@ -146,6 +159,7 @@ describe Scaffolding::BlockManipulator do
         <% end %>
 
       RESULT
+    assert_equal(File.readlines(file_path), new_lines)
     assert_equal(File.read(file_path), expected_result)
   end
 
@@ -160,10 +174,12 @@ describe Scaffolding::BlockManipulator do
 
       INITIAL
     initialize_demo_file(file_path, initial_data)
-    block_manipulator = Scaffolding::BlockManipulator.new(file_path)
-    block_manipulator.insert_block(["<% new_block do %>", "<% end %>"], after_block: "<% inner_block")
-    block_manipulator.insert("  an inner line", within: "<% new_block")
-    block_manipulator.write
+    initial_lines = File.readlines(file_path)
+
+    new_lines = Scaffolding::BlockManipulator.insert_block(["<% new_block do %>", "<% end %>"], after_block: "<% inner_block", lines: initial_lines)
+    new_lines = Scaffolding::BlockManipulator.insert("  an inner line", within: "<% new_block", lines: new_lines)
+    Scaffolding::FileManipulator.write(file_path, new_lines, strip: false)
+
     expected_result =
       <<~EXPECTED
 
@@ -176,22 +192,24 @@ describe Scaffolding::BlockManipulator do
         <% end %>
 
       EXPECTED
+    assert_equal(File.readlines(file_path), new_lines)
     assert_equal(File.read(file_path), expected_result)
   end
 
   it "Wraps a block with a new block" do
-    initial_data_state =
+    initial_data =
       <<~DATA
 
         <% test_block do %>
         <% end %>
 
       DATA
+    initialize_demo_file(file_path, initial_data)
+    initial_lines = File.readlines(file_path)
+    
+    new_lines = Scaffolding::BlockManipulator.wrap_block(starting: "<% test_block", with: ["<% outer_block do %>", "<% end %>"], lines: initial_lines)
+    Scaffolding::FileManipulator.write(file_path, new_lines, strip: false)
 
-    initialize_demo_file(file_path, initial_data_state)
-    block_manipulator = Scaffolding::BlockManipulator.new(file_path)
-    block_manipulator.wrap_block(starting: "<% test_block", with: ["<% outer_block do %>", "<% end %>"])
-    block_manipulator.write
     expected_result =
       <<~RESULT
 
@@ -201,11 +219,12 @@ describe Scaffolding::BlockManipulator do
         <% end %>
 
       RESULT
+    assert_equal(File.readlines(file_path), new_lines)
     assert_equal(File.read(file_path), expected_result)
   end
 
   it "Wraps a nested block" do
-    initial_state =
+    initial_data =
       <<~INITIAL
 
         <% test_block do %>
@@ -214,6 +233,12 @@ describe Scaffolding::BlockManipulator do
         <% end %>
 
       INITIAL
+    initialize_demo_file(file_path, initial_data)
+    initial_lines = File.readlines(file_path)
+
+    new_lines = Scaffolding::BlockManipulator.wrap_block(starting: "<% inner_block do", with: ["<% wrapping_block do %>", "<% end %>"], lines: initial_lines)
+    Scaffolding::FileManipulator.write(file_path, new_lines, strip: false)
+
     expected_result =
       <<~RESULT
 
@@ -225,10 +250,7 @@ describe Scaffolding::BlockManipulator do
         <% end %>
 
       RESULT
-    initialize_demo_file(file_path, initial_state)
-    block_manipulator = Scaffolding::BlockManipulator.new(file_path)
-    block_manipulator.wrap_block(starting: "<% inner_block do", with: ["<% wrapping_block do %>", "<% end %>"])
-    block_manipulator.write
+    assert_equal(File.readlines(file_path), new_lines)
     assert_equal(File.read(file_path), expected_result)
   end
 end

--- a/test/lib/scaffolding/block_manipulator_test.rb
+++ b/test/lib/scaffolding/block_manipulator_test.rb
@@ -206,7 +206,7 @@ describe Scaffolding::BlockManipulator do
       DATA
     initialize_demo_file(file_path, initial_data)
     initial_lines = File.readlines(file_path)
-    
+
     new_lines = Scaffolding::BlockManipulator.wrap_block(starting: "<% test_block", with: ["<% outer_block do %>", "<% end %>"], lines: initial_lines)
     Scaffolding::FileManipulator.write(file_path, new_lines, strip: false)
 

--- a/test/lib/scaffolding/examples/block_manipulator_data.html.erb
+++ b/test/lib/scaffolding/examples/block_manipulator_data.html.erb
@@ -1,3 +1,4 @@
 
 <% test_block do %>
+  <p>with some content</p>
 <% end %>

--- a/test/lib/scaffolding/routes_file_manipulator_test.rb
+++ b/test/lib/scaffolding/routes_file_manipulator_test.rb
@@ -102,7 +102,7 @@ describe Scaffolding::RoutesFileManipulator do
     examples.each do |starting_line_number, ending_line_number|
       it "returns #{ending_line_number} for #{starting_line_number}" do
         results = subject.new(example_file, "Something", "Nothing")
-        results = results.block_manipulator.find_block_end(starting_from: starting_line_number, lines: results.lines)
+        results = Scaffolding::BlockManipulator.find_block_end(starting_from: starting_line_number, lines: results.lines)
         assert_equal ending_line_number, results
       end
     end


### PR DESCRIPTION
There are still some methods in the `RoutesFileManipulator` to extract to the `BlockManipulator`, but this will at least allow us to use the `BlockManipulator` as a module.

I did this for two reasons:
1. Readability.
2. Keeping track of `lines`.

## Details
Especially for the 2nd point, the lines were very easily diverging from one another whenever we saved them as two different variables, once inside a `BlockManipulator` instance and one more time inside a `RoutesFileManipulator` instance. With this new code, handling our lines with a module will force us to keep track of our lines on the surface without having any fear of splitting them between objects and losing track of what's going on. The Scaffolding code is already complicated as it is, so debugging can get pretty tough when we're not sure what's coming from where. That's why I think using modules like this will make the code more readable, and we can even break down the code into smaller bits if we want to in the future. For example:

```ruby
# Taken from `top_level_namespace_block_lines`:
starting_line_number = local_namespace[namespace_name]
local_namespace_block = ((starting_line_number + 1)..(Scaffolding::BlockManipulator.find_block_end(starting_from: starting_line_number, lines: lines) + 1))

# We could change it to this:
starting_line_number = local_namespace[namespace_name]
block_end_line_number = Scaffolding::BlockManipulator.find_block_end(starting_from: starting_line_number, lines: lines)
local_namespace_block = ((starting_line_number + 1)..(block_end_line_number + 1))
```