### PR TITLE
Ensure jbuilder files use correct partial

### DIFF
--- a/lib/scaffolding/transformer.rb
+++ b/lib/scaffolding/transformer.rb
@@ -1069,8 +1069,8 @@ class Scaffolding::Transformer
           end
         end
 
-        # We need to update the jbuilder views for our
-        # new Tangible Thing if it's scoped under "account".
+        # We need to update our new Tangible Thing's
+        # jbuilder files if it's scoped under "account".
         # TODO: Should we run this if `namespace.present?` instead?
         if namespace == "account"
           target_string = "#{transform_string("scaffolding/completely_concrete/tangible_things")}/#{transform_string("tangible_thing")}"

--- a/lib/scaffolding/transformer.rb
+++ b/lib/scaffolding/transformer.rb
@@ -1068,6 +1068,20 @@ class Scaffolding::Transformer
             scaffold_add_line_to_file("./test/controllers/api/v1/scaffolding/completely_concrete/tangible_things_endpoint_test.rb", "assert_equal @tangible_thing.#{name}, #{attribute_assignment}", RUBY_EVEN_MORE_NEW_FIELDS_HOOK, prepend: true)
           end
         end
+
+        # We need to update the jbuilder views for our
+        # new Tangible Thing if it's scoped under "account".
+        # TODO: Should we run this if `namespace.present?` instead?
+        if namespace == "account"
+          target_string = "#{transform_string("scaffolding/completely_concrete/tangible_things")}/#{transform_string("tangible_thing")}"
+          replacement_string = "#{namespace}/#{target_string}"
+          [
+            "app/views/account/completely_concrete/tangible_things/index.json.jbuilder",
+            "app/views/account/completely_concrete/tangible_things/show.json.jbuilder"
+          ].each do |path|
+            scaffold_replace_line_in_file(path, replacement_string, target_string)
+          end
+        end
       end
 
       #


### PR DESCRIPTION
Closes #19.

This fix makes sure our `index` and `show` actions return the proper response when accessing links such as the following:

`http://localhost:3000/account/teams/bJYLew/contacts.json`
`http://localhost:3000/account/contacts/WjNwvM.json`

![jbuilder index](https://user-images.githubusercontent.com/10546292/184758795-2ae90d52-3a56-4d30-81e5-526becc03c3a.png)

![jbuilder show](https://user-images.githubusercontent.com/10546292/184758805-ad1eb7fa-ca5e-4cea-a738-559520570774.png)
