### PR TITLE
Silence output when Super Scaffolding a model

### DIFF
--- a/lib/scaffolding/file_manipulator.rb
+++ b/lib/scaffolding/file_manipulator.rb
@@ -66,7 +66,7 @@ module Scaffolding::FileManipulator
   end
 
   def self.write(file_name, lines, strip: true)
-    puts "Updating '#{file_name}'." unless silence_logs?
+    puts "Updating '#{file_name}'." unless ENV["SILENCE_LOGS"].present?
     if strip
       File.open(file_name, "w+") do |file|
         file.puts(lines.join.strip + "\n")

--- a/lib/scaffolding/file_manipulator.rb
+++ b/lib/scaffolding/file_manipulator.rb
@@ -23,7 +23,7 @@ module Scaffolding::FileManipulator
     if target_file_content.include?(content)
       puts "No need to update '#{file}'. It already has '#{content}'."
     else
-      puts "Updating '#{file}'."
+      puts "Updating '#{file}'." unless silence_logs?
       target_file_content.gsub!(in_place_of, content)
       File.write(file, target_file_content)
     end
@@ -63,7 +63,7 @@ module Scaffolding::FileManipulator
   end
 
   def self.write(file_name, lines)
-    puts "Updating '#{file_name}'."
+    puts "Updating '#{file_name}'." unless silence_logs?
     File.open(file_name, "w+") do |file|
       file.puts(lines.join.strip + "\n")
     end

--- a/lib/scaffolding/oauth_providers.rb
+++ b/lib/scaffolding/oauth_providers.rb
@@ -11,7 +11,7 @@ def legacy_resolve_template_path(file)
 end
 
 def legacy_replace_in_file(file, before, after)
-  puts "Replacing in '#{file}'."
+  puts "Replacing in '#{file}'." unless silence_logs?
   target_file_content = File.read(file)
   target_file_content.gsub!(before, after)
   File.write(file, target_file_content)
@@ -58,7 +58,7 @@ def legacy_add_line_to_file(file, content, hook, child, parent, options = {})
       end
     end
 
-    puts "Updating '#{transformed_file_name}'."
+    puts "Updating '#{transformed_file_name}'." unless silence_logs?
 
     File.write(transformed_file_name, new_target_file_content.join("\n") + "\n")
   end
@@ -137,7 +137,7 @@ def oauth_scaffold_file(file, options)
     FileUtils.mkdir_p(transformed_directory_name)
   end
 
-  puts "Writing '#{transformed_file_name}'."
+  puts "Writing '#{transformed_file_name}'." unless silence_logs?
 
   File.write(transformed_file_name, transformed_file_content)
 end

--- a/lib/scaffolding/transformer.rb
+++ b/lib/scaffolding/transformer.rb
@@ -238,12 +238,12 @@ class Scaffolding::Transformer
       FileUtils.mkdir_p(transformed_directory_name)
     end
 
-    puts "Writing '#{transformed_file_name}'."
+    puts "Writing '#{transformed_file_name}'." unless silence_logs?
 
     File.write(transformed_file_name, transformed_file_content.strip + "\n")
 
     if transformed_file_name.split(".").last == "rb"
-      puts "Fixing Standard Ruby on '#{transformed_file_name}'."
+      puts "Fixing Standard Ruby on '#{transformed_file_name}'." unless silence_logs?
       # `standardrb --fix #{transformed_file_name} 2> /dev/null`
     end
   end
@@ -283,7 +283,7 @@ class Scaffolding::Transformer
     end
 
     if target_file_content.include?(transformed_content)
-      puts "No need to update '#{transformed_file_name}'. It already has '#{transformed_content}'."
+      puts "No need to update '#{transformed_file_name}'. It already has '#{transformed_content}'." unless silence_logs?
 
     else
 
@@ -333,7 +333,7 @@ class Scaffolding::Transformer
         end
       end
 
-      puts "Updating '#{transformed_file_name}'."
+      puts "Updating '#{transformed_file_name}'." unless silence_logs?
 
       File.write(transformed_file_name, new_target_file_content.join("\n").strip + "\n")
 
@@ -475,7 +475,7 @@ class Scaffolding::Transformer
   end
 
   def replace_in_file(file, before, after, target_regexp = nil)
-    puts "Replacing in '#{file}'."
+    puts "Replacing in '#{file}'." unless silence_logs?
     if target_regexp.present?
       target_file_content = ""
       File.open(file).each_line do |l|


### PR DESCRIPTION
I don't mind the output, but sometimes I like to see everything in my terminal without having to scroll back up, so although it's not necessary, I thought it would be nice to have the option to silence the Super Scaffolding console output.

This can be enabled by adding the following to `config/application.yml`:
```yml
SILENCE_LOGS: "true"
```

### The Result

![Silenced Logs](https://user-images.githubusercontent.com/10546292/185265799-ead482fe-f8f7-4265-b6c3-394fd793cdca.png)

Joint PR
- https://github.com/bullet-train-co/bullet_train-base/pull/98