### PR TITLE
Raise error in console for `RoutesFileManipulator#apply`

### DIFF
--- a/lib/scaffolding/transformer.rb
+++ b/lib/scaffolding/transformer.rb
@@ -1420,8 +1420,9 @@ class Scaffolding::Transformer
 
       begin
         routes_manipulator.apply([routes_namespace])
-      rescue
-        add_additional_step :yellow, "We weren't able to automatically add your `#{routes_namespace}` routes for you. In theory this should be very rare, so if you could reach out on Slack, you could probably provide context that will help us fix whatever the problem was. In the meantime, to add the routes manually, we've got a guide at https://blog.bullettrain.co/nested-namespaced-rails-routing-examples/ ."
+      rescue => e
+        puts "We weren't able to automatically add your `#{routes_namespace}` routes for you. In theory this should be very rare, so if you could reach out on Slack, you could probably provide context that will help us fix whatever the problem was. In the meantime, to add the routes manually, we've got a guide at https://blog.bullettrain.co/nested-namespaced-rails-routing-examples/ .".send(:yellow)
+        raise e
       end
 
       Scaffolding::FileManipulator.write("config/routes.rb", routes_manipulator.lines)


### PR DESCRIPTION
Closes #58.

## Details
`routes_file_manipulator.apply([routes_namespace])` on line 1422 of the Transformer would catch all of our errors (whether in the `RoutesFileManipulator` itself or any other modules it was calling like the `FileManipulator`), but we weren't specifying the error itself, and then we just let the process run as usual.

Although it's very general, I made sure we raise the error here so we don't miss any bugs when working in the `RoutesFileManipulator` or any other related classes or modules.

The `additional_steps` portion gets cut though, so if we want to handle that differently I'm open to ideas.

## The error logs
Following the example in #58, we put the following in `RoutesFileManipulator#insert_before`
```ruby
def insert_before(new_lines, line_number, options = {})
  puts "Will run"
  foo # Undefined variable
  puts "Won't run"

  options[:indent] ||= false
  before = lines[0..(line_number - 1)]
  new_lines = new_lines.map { |line| (block_manipulator.indentation_of(line_number, lines) + (options[:indent] ? "  " : "") + line).gsub(/\s+$/, "") + "\n" }
  after = lines[line_number..]
  self.lines = before + (options[:prepend_newline] ? ["\n"] : []) + new_lines + after
end
```

<details>
 <summary>We now get these logs</summary>

```
> bin/super-scaffold crud Project Team title:text_field --sidebar="ti.ti-world"
Writing './app/controllers/account/projects_controller.rb'.
Fixing Standard Ruby on './app/controllers/account/projects_controller.rb'.
Writing './app/views/account/projects/_index.html.erb'.
Writing './app/views/account/projects/_form.html.erb'.
Writing './app/views/account/projects/_menu_item.html.erb'.
Writing './app/views/account/projects/show.json.jbuilder'.
Writing './app/views/account/projects/index.html.erb'.
Writing './app/views/account/projects/_project.json.jbuilder'.
Writing './app/views/account/projects/index.json.jbuilder'.
Writing './app/views/account/projects/edit.html.erb'.
Writing './app/views/account/projects/show.html.erb'.
Writing './app/views/account/projects/_breadcrumbs.html.erb'.
Writing './app/views/account/projects/new.html.erb'.
Writing './config/locales/en/projects.en.yml'.
Writing './app/controllers/api/v1/projects_endpoint.rb'.
Fixing Standard Ruby on './app/controllers/api/v1/projects_endpoint.rb'.
Writing './test/controllers/api/v1/projects_endpoint_test.rb'.
Fixing Standard Ruby on './test/controllers/api/v1/projects_endpoint_test.rb'.
Writing './app/serializers/api/v1/project_serializer.rb'.
Fixing Standard Ruby on './app/serializers/api/v1/project_serializer.rb'.
Updating './app/controllers/api/v1/root.rb'.
Updating './test/factories/projects.rb'.
Updating './app/models/team.rb'.
Updating './test/controllers/api/v1/projects_endpoint_test.rb'.
Updating './app/views/account/teams/show.html.erb'.
Updating './app/models/project.rb'.
Updating './app/models/project.rb'.
Updating './app/views/account/projects/_form.html.erb'.
Updating './app/views/account/projects/show.html.erb'.
Updating './app/views/account/projects/_index.html.erb'.
Updating './app/views/account/projects/_index.html.erb'.
Updating './config/locales/en/projects.en.yml'.
Updating './config/locales/en/projects.en.yml'.
Updating './app/controllers/account/projects_controller.rb'.
Updating './app/controllers/api/v1/projects_endpoint.rb'.
Updating './app/views/account/projects/_project.json.jbuilder'.
Updating './app/serializers/api/v1/project_serializer.rb'.
Updating './test/controllers/api/v1/projects_endpoint_test.rb'.
Updating './test/controllers/api/v1/projects_endpoint_test.rb'.
Updating './test/controllers/api/v1/projects_endpoint_test.rb'.
Updating './app/models/project.rb'.
Updating './config/locales/en/projects.en.yml'.
Replacing in './config/locales/en/projects.en.yml'.
Will run
We weren't able to automatically add your `account` routes for you. In theory this should be very rare, so if you could reach out on Slack, you could probably provide context that will help us fix whatever the problem was. In the meantime, to add the routes manually, we've got a guide at https://blog.bullettrain.co/nested-namespaced-rails-routing-examples/ .
rake aborted!
NameError: undefined local variable or method `foo' for #<Scaffolding::RoutesFileManipulator:0x00007fc12f20fab0 @child="Project", @parent="Team", @filename="config/routes.rb", @lines=["Rails.application.routes.draw do\n", "  # See `config/routes/*.rb` to customize these configurations.\n", "  draw \"concerns\"\n", "  draw \"devise\"\n", "  draw \"sidekiq\"\n", "\n", "  # This is helpful to have around when working with shallow routes and complicated model namespacing. We don't use this\n", "  # by default, but sometimes Super Scaffolding will generate routes that use this for `only` and `except` options.\n", "  # TODO Would love to get this out of the application routes file.\n", "  collection_actions = [:index, :new, :create]\n", "\n", "  # This helps mark `resources` definitions below as not actually defining the routes for a given resource, but just\n", "  # making it possible for developers to extend definitions that are already defined by the `bullet_train` Ruby gem.\n", "  # TODO Would love to get this out of the application routes file.\n", "  extending = {only: []}\n", "\n", "  scope module: \"public\" do\n", "    # To keep things organized, we put non-authenticated controllers in the `Public::` namespace.\n", "    # The root `/` path is routed to `Public::HomeController#index` by default.\n", "  end\n", "\n", "  namespace :webhooks do\n", "    namespace :incoming do\n", "      resources :bullet_train_webhooks\n", "      namespace :oauth do\n", "        # 🚅 super scaffolding will insert new oauth provider webhooks above this line.\n", "      end\n", "    end\n", "  end\n", "\n", "  namespace :account do\n", "    shallow do\n", "      # user-level onboarding tasks.\n", "      namespace :onboarding do\n", "        # routes for standard onboarding steps are configured in the `bullet_train` gem, but you can add more here.\n", "      end\n", "\n", "      # user specific resources.\n", "      resources :users, extending do\n", "        namespace :oauth do\n", "          # 🚅 super scaffolding will insert new oauth providers above this line.\n", "        end\n", "\n", "        # routes for standard user actions and resources are configured in the `bullet_train` gem, but you can add more here.\n", "      end\n", "\n", "      # team-level resources.\n", "      resources :teams, extending do\n", "        # routes for many teams actions and resources are configured in the `bullet_train` gem, but you can add more here.\n", "\n", "        # add your resources here.\n", "\n", "        resources :invitations, extending do\n", "          # routes for standard invitation actions and resources are configured in the `bullet_train` gem, but you can add more here.\n", "        end\n", "\n", "        resources :memberships, extending do\n", "          # routes for standard membership actions and resources are configured in the `bullet_train` gem, but you can add more here.\n", "        end\n", "\n", "        namespace :integrations do\n", "          # 🚅 super scaffolding will insert new integration installations above this line.\n", "        end\n", "\n", "        namespace :platform do\n", "          resources :applications\n", "        end\n", "      end\n", "    end\n", "  end\n", "end\n"], @transformer_options={"sidebar"=>"ti.ti-world"}, @block_manipulator=#<Scaffolding::BlockManipulator:0x00007fc12f20ea70 @filepath="config/routes.rb", @lines=["Rails.application.routes.draw do\n", "  # See `config/routes/*.rb` to customize these configurations.\n", "  draw \"concerns\"\n", "  draw \"devise\"\n", "  draw \"sidekiq\"\n", "\n", "  # This is helpful to have around when working with shallow routes and complicated model namespacing. We don't use this\n", "  # by default, but sometimes Super Scaffolding will generate routes that use this for `only` and `except` options.\n", "  # TODO Would love to get this out of the application routes file.\n", "  collection_actions = [:index, :new, :create]\n", "\n", "  # This helps mark `resources` definitions below as not actually defining the routes for a given resource, but just\n", "  # making it possible for developers to extend definitions that are already defined by the `bullet_train` Ruby gem.\n", "  # TODO Would love to get this out of the application routes file.\n", "  extending = {only: []}\n", "\n", "  scope module: \"public\" do\n", "    # To keep things organized, we put non-authenticated controllers in the `Public::` namespace.\n", "    # The root `/` path is routed to `Public::HomeController#index` by default.\n", "  end\n", "\n", "  namespace :webhooks do\n", "    namespace :incoming do\n", "      resources :bullet_train_webhooks\n", "      namespace :oauth do\n", "        # 🚅 super scaffolding will insert new oauth provider webhooks above this line.\n", "      end\n", "    end\n", "  end\n", "\n", "  namespace :account do\n", "    shallow do\n", "      # user-level onboarding tasks.\n", "      namespace :onboarding do\n", "        # routes for standard onboarding steps are configured in the `bullet_train` gem, but you can add more here.\n", "      end\n", "\n", "      # user specific resources.\n", "      resources :users, extending do\n", "        namespace :oauth do\n", "          # 🚅 super scaffolding will insert new oauth providers above this line.\n", "        end\n", "\n", "        # routes for standard user actions and resources are configured in the `bullet_train` gem, but you can add more here.\n", "      end\n", "\n", "      # team-level resources.\n", "      resources :teams, extending do\n", "        # routes for many teams actions and resources are configured in the `bullet_train` gem, but you can add more here.\n", "\n", "        # add your resources here.\n", "\n", "        resources :invitations, extending do\n", "          # routes for standard invitation actions and resources are configured in the `bullet_train` gem, but you can add more here.\n", "        end\n", "\n", "        resources :memberships, extending do\n", "          # routes for standard membership actions and resources are configured in the `bullet_train` gem, but you can add more here.\n", "        end\n", "\n", "        namespace :integrations do\n", "          # 🚅 super scaffolding will insert new integration installations above this line.\n", "        end\n", "\n", "        namespace :platform do\n", "          resources :applications\n", "        end\n", "      end\n", "    end\n", "  end\n", "end\n"]>, @divergent_namespaces=[[], "projects", [], "teams"], @child_parts=["projects"], @parent_parts=["teams"]>

    foo # Undefined variable
    ^^^
/home/gazayas/work/bt/bullet_train-super_scaffolding/lib/scaffolding/routes_file_manipulator.rb:88:in `insert_before'
/home/gazayas/work/bt/bullet_train-super_scaffolding/lib/scaffolding/routes_file_manipulator.rb:316:in `insert'
/home/gazayas/work/bt/bullet_train-super_scaffolding/lib/scaffolding/routes_file_manipulator.rb:223:in `find_or_create_resource'
/home/gazayas/work/bt/bullet_train-super_scaffolding/lib/scaffolding/routes_file_manipulator.rb:382:in `apply'
/home/gazayas/work/bt/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb:1422:in `scaffold_crud'
/home/gazayas/work/bt/bullet_train-super_scaffolding/lib/bullet_train/super_scaffolding/scaffolders/crud_scaffolder.rb:51:in `run'
/home/gazayas/work/bt/bullet_train-super_scaffolding/lib/scaffolding/script.rb:107:in `<main>'
/home/gazayas/work/bt/bullet_train-super_scaffolding/lib/bullet_train/super_scaffolding.rb:25:in `run'
/home/gazayas/work/bt/bullet_train-super_scaffolding/lib/tasks/bullet_train/super_scaffolding_tasks.rake:10:in `block (2 levels) in <main>'
Tasks: TOP => bullet_train:super_scaffolding
(See full trace by running task with --trace)
>
```
</details>
