### PR TITLE
Fix Standard Ruby for miscellaneous files

### DIFF
--- a/.standard.yml
+++ b/.standard.yml
@@ -2,7 +2,4 @@ ignore:
   - 'lib/scaffolding/transformer.rb':
     - Layout/EndAlignment
   # TODO Fix these files up for Standard Ruby.
-  - 'lib/scaffolding/script.rb'
-  - 'lib/bullet_train/super_scaffolding/scaffolders/crud_field_scaffolder.rb'
-  - 'lib/bullet_train/super_scaffolding/scaffolders/crud_scaffolder.rb'
   - 'lib/bullet_train/super_scaffolding/scaffolders/oauth_provider_scaffolder.rb'

--- a/lib/bullet_train/super_scaffolding/scaffolders/crud_field_scaffolder.rb
+++ b/lib/bullet_train/super_scaffolding/scaffolders/crud_field_scaffolder.rb
@@ -24,7 +24,7 @@ module BulletTrain
           child = argv[0]
 
           # get all the attributes.
-          attributes = argv[1..-1]
+          attributes = argv[1..]
 
           check_required_options_for_attributes("crud-field", attributes, child)
 

--- a/lib/bullet_train/super_scaffolding/scaffolders/crud_scaffolder.rb
+++ b/lib/bullet_train/super_scaffolding/scaffolders/crud_scaffolder.rb
@@ -36,14 +36,14 @@ module BulletTrain
           parent = parents.first
 
           unless parents.include?("Team")
-            raise "Parents for #{child} should trace back to the Team model, but Team wasn't provided. Please confirm that all of the parents tracing back to the Team model are present and try again.\n" +
-              "E.g.:\n" +
-              "rails g model Section page:references title:text body:text\n" +
+            raise "Parents for #{child} should trace back to the Team model, but Team wasn't provided. Please confirm that all of the parents tracing back to the Team model are present and try again.\n" \
+              "E.g.:\n" \
+              "rails g model Section page:references title:text body:text\n" \
               "bin/super-scaffold crud Section Page,Site,Team title:text body:text\n"
           end
 
           # get all the attributes.
-          attributes = argv[2..-1]
+          attributes = argv[2..]
 
           check_required_options_for_attributes("crud", attributes, child, parent)
 

--- a/lib/scaffolding/script.rb
+++ b/lib/scaffolding/script.rb
@@ -15,7 +15,7 @@ argv = []
 @options = {}
 ARGV.each do |arg|
   if arg[0..1] == "--"
-    arg = arg[2..-1]
+    arg = arg[2..]
     if arg.split("=").count > 1
       @options[arg.split("=")[0]] = arg.split("=")[1]
     else
@@ -38,9 +38,9 @@ def check_required_options_for_attributes(scaffolding_type, attributes, child, p
     type = parts.join(":")
 
     unless Scaffolding.valid_attribute_type?(type)
-      raise "You have entered an invalid attribute type: #{type}. General data types are used when creating new models, but Bullet Train " +
-            "uses field partials when Super Scaffolding, i.e. - `name:text_field` as opposed to `name:string`. " +
-            "Please refer to the Field Partial documentation to view which attribute types are available."
+      raise "You have entered an invalid attribute type: #{type}. General data types are used when creating new models, but Bullet Train " \
+        "uses field partials when Super Scaffolding, i.e. - `name:text_field` as opposed to `name:string`. " \
+        "Please refer to the Field Partial documentation to view which attribute types are available."
     end
 
     # extract any options they passed in with the field.


### PR DESCRIPTION
Addresses the TODO in `.standard.yml`

I left the OAuth provider scaffolder as is since I don't think we're technically testing it with the Super Scaffolding system test, but I'll double check and edit that file as well if we are.