### PR TITLE
Remove `action_model_select_controller` from Super Scaffolding

### DIFF
--- a/app/helpers/super_scaffolding_helper.rb
+++ b/app/helpers/super_scaffolding_helper.rb
@@ -1,2 +1,10 @@
 module SuperScaffoldingHelper
+  unless defined?(BulletTrain::ActionModels)
+    def action_model_select_controller
+      # TODO I don't know why if I just call `yield` I get duplicate content on the page.
+      # tag.div do
+      #   yield
+      # end
+    end
+  end
 end

--- a/app/helpers/super_scaffolding_helper.rb
+++ b/app/helpers/super_scaffolding_helper.rb
@@ -1,10 +1,2 @@
 module SuperScaffoldingHelper
-  unless defined?(BulletTrain::ActionModels)
-    def action_model_select_controller
-      # TODO I don't know why if I just call `yield` I get duplicate content on the page.
-      tag.div do
-        yield
-      end
-    end
-  end
 end


### PR DESCRIPTION
## The goal
The full implementation of this has been moved over to a helper in Action Models and I'm not seeing any invocation of it in any of the other repositories so I think it would make sense to delete this method.

`yield` is still being wrapped by a div tag in the new code, but I didn't see a TODO there so I'm assuming there currently aren't any issues with it.

## The current problem
The Minitest suite is passing locally, and super scaffolding a model that invokes `<%= action_model_select_controller do %> ... <% end %>` works fine in the browser even when Action Models isn't defined in the main Bullet Train application. However, the tests are failing on CircleCI.

Also, tests will pass when running `CI=true bundle exec rails test`, so it doesn't seem to be a constant loading issue either.

