### PR TITLE
Super Scaffold booleans with `default: false` in migration

### DIFF
--- a/lib/scaffolding/transformer.rb
+++ b/lib/scaffolding/transformer.rb
@@ -1163,6 +1163,25 @@ class Scaffolding::Transformer
           end
         end
 
+        # Add `default: false` to boolean migrations.
+        if boolean_buttons
+          confirmation_reference = "create_table :#{class_names_transformer.table_name}"
+          confirmation_migration_file_name = `grep "#{confirmation_reference}" db/migrate/*`.split(":").first
+
+          old_line, new_line = nil
+          File.open(confirmation_migration_file_name) do |migration_file|
+            old_lines = migration_file.readlines
+            old_lines.each do |line|
+              target_attribute = line.match?(/\s*t\.boolean :#{name}/)
+              if target_attribute
+                old_line = line
+                new_line = "#{old_line.chomp}, default: false\n"
+              end
+            end
+          end
+          replace_in_file(confirmation_migration_file_name, old_line, new_line)
+        end
+
       end
 
       #


### PR DESCRIPTION
Closes #70.

1. I made sure we got the whole line before adding `default: false` to the end instead of simply taking `t.boolean :foo` and replacing it with `t.boolean :foo, default: false` just in case any other options were already added before.
2. I ended up duplicating the code that gets the proper migration file name, so I added a TODO because I'll have to think through how to refactor this one first. Although variables like `confirmation_reference` and `expected_reference` are almost the same, they are handled slightly differently. I don't want to jump the gun, so I'll see if I can refactor that part in a different PR.