### PR TITLE
Use `BlockManipulator` exclusively for `insert` methods in `RoutesFileManipulator`

### DIFF
--- a/lib/scaffolding/block_manipulator.rb
+++ b/lib/scaffolding/block_manipulator.rb
@@ -104,9 +104,10 @@ module Scaffolding::BlockManipulator
     lines.each_with_index do |line, index|
       indent = line.match(/^\s*/).to_s
 
-      # If the line we're about to add the new line under is
-      # the start of a block, we need to add the proper indentation.
-      indent += "\s" * 2 if line.match?(/do$/)
+      # If `line` is the the start of a block, then `content`
+      # (what we want to add) should be indented.
+      # We DON'T indent `content` though if we're ending the block.
+      indent += "\s" * 2 if line.match?(/do$/) && !content.match(/end\n$/)
 
       final << line
       if index == insert_at_index

--- a/lib/scaffolding/block_manipulator.rb
+++ b/lib/scaffolding/block_manipulator.rb
@@ -114,8 +114,8 @@ module Scaffolding::BlockManipulator
 
         # If the new line we want to add is being added directly
         # after a block, we add a new line to put space between the two.
-        if /^\s*end\s*$/.match?(lines[insert_at_index])
-          content = "\n#{content}"
+        if /^\s*end\n$/.match?(lines[insert_at_index])
+          final << "\n"
         end
 
         final << content

--- a/lib/scaffolding/block_manipulator.rb
+++ b/lib/scaffolding/block_manipulator.rb
@@ -81,7 +81,7 @@ module Scaffolding::BlockManipulator
         if after.nil? || line.match?(after)
           unless append
             match = true
-            # We adjust the injection point if we really wanted to insert before.
+            # We adjust the insertion point if we really wanted to insert before.
             lines = insert_line(content, index - (before ? 1 : 0), lines)
           end
         end
@@ -105,7 +105,7 @@ module Scaffolding::BlockManipulator
       indent = line.match(/^\s*/).to_s
 
       # If the line we're about to add the new line under is
-      # the start of a block, we need to add the proper indentation.nt
+      # the start of a block, we need to add the proper indentation.
       indent += "\s" * 2 if line.match?(/do$/)
 
       final << line

--- a/lib/scaffolding/block_manipulator.rb
+++ b/lib/scaffolding/block_manipulator.rb
@@ -72,12 +72,6 @@ module Scaffolding::BlockManipulator
     index = start_line
     match = false
 
-    # If the new line we want to add is being added directly
-    # after a block, we add a new line to put space between the two.
-    if /^\s*end\s*$/.match?(lines[insertion_point - 1])
-      content = "\n#{content}"
-    end
-
     if insertion_point.present?
       lines = insert_line(content, insertion_point - (before ? 1 : 0), lines)
       return lines
@@ -109,9 +103,22 @@ module Scaffolding::BlockManipulator
     final = []
     lines.each_with_index do |line, index|
       indent = line.match(/^\s*/).to_s
+
+      # If the line we're about to add the new line under is
+      # the start of a block, we need to add the proper indentation.nt
+      indent += "\s" * 2 if line.match?(/do$/)
+
       final << line
       if index == insert_at_index
-        final << indent + content
+        content = indent + content
+
+        # If the new line we want to add is being added directly
+        # after a block, we add a new line to put space between the two.
+        if /^\s*end\s*$/.match?(lines[insert_at_index])
+          content = "\n#{content}"
+        end
+
+        final << content
       end
     end
     final

--- a/lib/scaffolding/routes_file_manipulator.rb
+++ b/lib/scaffolding/routes_file_manipulator.rb
@@ -218,11 +218,12 @@ class Scaffolding::RoutesFileManipulator
     unless (result = find_resource([resource], options))
       # We want to place this at the end of the block.
       insertion_point = Scaffolding::BlockManipulator.find_block_end(starting_from: options[:within], lines: lines)
-      block_indentation = Scaffolding::BlockManipulator.indentation_of(insertion_point, lines) + "  "
+      block_indentation = Scaffolding::BlockManipulator.indentation_of(insertion_point, lines)
+      line_to_add = "resources :#{resource}" + (options[:options] ? ", #{options[:options]}" : "")
 
       # We set `before` to true to make sure the line sits right above the block's `end`.
       new_lines = Scaffolding::BlockManipulator.insert(
-        "#{block_indentation}resources :#{resource}" + (options[:options] ? ", #{options[:options]}" : ""),
+        line_to_add,
         within: namespace_within || options[:within],
         insertion_point: insertion_point,
         before: true,
@@ -351,6 +352,12 @@ class Scaffolding::RoutesFileManipulator
       line = "scope module: '#{parent_resource}' do"
       # TODO you haven't tested this yet.
       unless (scope_within = Scaffolding::FileManipulator.find(lines, /#{line}/, parent_within))
+        # Create the new scope block
+        # @lines = Scaffolding::BlockManipulator.insert("  #{line}", lines: @lines, insertion_point: parent_within, after: true)
+        # @lines = Scaffolding::BlockManipulator.insert("end", lines: @lines, insertion_point: parent_within + 1, after: true)
+        # Scaffolding::FileManipulator.write(@filename, @lines)
+        # new_scope_line = @lines.select{|new_line| new_line.match?(line)}.first
+        # scope_within = @lines.index(new_scope_line)
         scope_within = insert([line, "end"], parent_within)
       end
 

--- a/lib/scaffolding/routes_file_manipulator.rb
+++ b/lib/scaffolding/routes_file_manipulator.rb
@@ -232,6 +232,8 @@ class Scaffolding::RoutesFileManipulator
       # TODO: We still have to update the lines for now, but we should do away with @lines eventually.
       @lines = new_lines
       Scaffolding::FileManipulator.write(@filename, new_lines)
+
+      # TODO: I think this should be an int instead of the line itself
       result = lines[insertion_point]
     end
     result

--- a/lib/scaffolding/routes_file_manipulator.rb
+++ b/lib/scaffolding/routes_file_manipulator.rb
@@ -328,21 +328,6 @@ class Scaffolding::RoutesFileManipulator
     within
   end
 
-  # TODO: Remove this and use the BlockManipulator
-  def insert(lines_to_add, within)
-    insertion_line = Scaffolding::BlockManipulator.find_block_end(starting_from: within, lines: lines)
-    result_line = insertion_line
-    unless insertion_line == within + 1
-      # only put the extra space if we're adding this line after a block
-      if /^\s*end\s*$/.match?(lines[insertion_line - 1])
-        lines_to_add.unshift("")
-        result_line += 1
-      end
-    end
-    insert_before(lines_to_add, insertion_line, indent: true)
-    result_line
-  end
-
   def apply(base_namespaces)
     child_namespaces, child_resource, parent_namespaces, parent_resource = divergent_parts
 

--- a/lib/scaffolding/routes_file_manipulator.rb
+++ b/lib/scaffolding/routes_file_manipulator.rb
@@ -216,15 +216,17 @@ class Scaffolding::RoutesFileManipulator
     options[:ignore] = top_level_namespace_block_lines(options[:within]) || []
 
     unless (result = find_resource([resource], options))
+      within = namespace_within || options[:within]
+
       # We want to place this at the end of the block.
-      insertion_point = Scaffolding::BlockManipulator.find_block_end(starting_from: options[:within], lines: lines)
+      insertion_point = Scaffolding::BlockManipulator.find_block_end(starting_from: within, lines: lines)
       block_indentation = Scaffolding::BlockManipulator.indentation_of(insertion_point, lines)
       line_to_add = "resources :#{resource}" + (options[:options] ? ", #{options[:options]}" : "")
 
       # We set `before` to true to make sure the line sits right above the block's `end`.
       new_lines = Scaffolding::BlockManipulator.insert(
         line_to_add,
-        within: namespace_within || options[:within],
+        within: within,
         insertion_point: insertion_point,
         before: true,
         lines: @lines,
@@ -234,8 +236,7 @@ class Scaffolding::RoutesFileManipulator
       @lines = new_lines
       Scaffolding::FileManipulator.write(@filename, new_lines)
 
-      # TODO: I think this should be an int instead of the line itself
-      result = lines[insertion_point]
+      result = insertion_point
     end
     result
   end

--- a/lib/scaffolding/routes_file_manipulator.rb
+++ b/lib/scaffolding/routes_file_manipulator.rb
@@ -354,12 +354,12 @@ class Scaffolding::RoutesFileManipulator
       # TODO you haven't tested this yet.
       unless (scope_within = Scaffolding::FileManipulator.find(lines, /#{line}/, parent_within))
         # Create the new scope block
-        # @lines = Scaffolding::BlockManipulator.insert("  #{line}", lines: @lines, insertion_point: parent_within, after: true)
-        # @lines = Scaffolding::BlockManipulator.insert("end", lines: @lines, insertion_point: parent_within + 1, after: true)
-        # Scaffolding::FileManipulator.write(@filename, @lines)
-        # new_scope_line = @lines.select{|new_line| new_line.match?(line)}.first
-        # scope_within = @lines.index(new_scope_line)
-        scope_within = insert([line, "end"], parent_within)
+        @lines = Scaffolding::BlockManipulator.insert(line, lines: @lines, insertion_point: parent_within, after: true)
+        @lines = Scaffolding::BlockManipulator.insert("end", lines: @lines, insertion_point: parent_within + 1, after: true)
+        Scaffolding::FileManipulator.write(@filename, @lines)
+
+        new_scope_line = @lines.select{|new_line| new_line.match?(line)}.first
+        scope_within = @lines.index(new_scope_line)
       end
 
       find_or_create_resource([child_resource], options: "only: collection_actions", within: scope_within)

--- a/lib/scaffolding/routes_file_manipulator.rb
+++ b/lib/scaffolding/routes_file_manipulator.rb
@@ -231,8 +231,8 @@ class Scaffolding::RoutesFileManipulator
 
       # TODO: We still have to update the lines for now, but we should do away with @lines eventually.
       @lines = new_lines
-      Scaffolding::FileManipulator.write("config/routes.rb", new_lines)
-      result = lines.index(insertion_point)
+      Scaffolding::FileManipulator.write(@filename, new_lines)
+      result = lines[insertion_point]
     end
     result
   end


### PR DESCRIPTION
Continuation of #53.

My goal with this PR is to fully replace `insert`, `insert_before`, and `insert_after`, but I'll at least start with `insert` and see how far I can get.