### PR TITLE
Use custom attribute name for color pickers

### DIFF
--- a/lib/scaffolding/transformer.rb
+++ b/lib/scaffolding/transformer.rb
@@ -811,7 +811,7 @@ class Scaffolding::Transformer
         end
 
         if type == "color_picker"
-          field_options[:color_picker_options] = "t('#{child.pluralize.underscore}.fields.color_picker_value.options')"
+          field_options[:color_picker_options] = "t('#{child.pluralize.underscore}.fields.#{name}.options')"
         end
 
         # TODO: This feels incorrect.


### PR DESCRIPTION
Closes https://github.com/bullet-train-co/bullet_train/issues/445
Found by @evanliewer.

## Details

Because we were creating the following string whenever we Super Scaffolded color pickers, we were getting an i18n error:
```ruby
field_options[:color_picker_options] = "t('#{child.pluralize.underscore}.fields.color_picker_value.options')"
```

`color_picker_value` here represents the attribute, so in this case the locale would only work if we named the attribute `color_picker_value`.

In this PR, I used the attribute name passed to the Transformer instead so developers can name the attribute to their liking, like so:
```
bundle exec rails g model Foo team:references hex_color:string
bin/super-scaffold crud Foo Team hex_color:color_picker --sidebar="ti.ti-tag"
```
