### PR TITLE
Define class by condition that depends on Starter Repo

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem "sqlite3"
 gem "sprockets-rails"
 
 gem "bullet_train", git: "git@github.com:bullet-train-co/bullet_train-base.git", branch: "ci-strong-params"
-gem "bullet_train-api"
+gem "bullet_train-api", git: "git@github.com:bullet-train-co/bullet_train-api.git", branch: "ci-strong-params"
 
 # Start debugger with binding.b [https://github.com/ruby/debug]
 # gem "debug", ">= 1.0.0"

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem "sqlite3"
 
 gem "sprockets-rails"
 
-gem "bullet_train"
+gem "bullet_train", git: "git@github.com:bullet-train-co/bullet_train-base.git", branch: "ci-strong-params"
 gem "bullet_train-api"
 
 # Start debugger with binding.b [https://github.com/ruby/debug]

--- a/app/controllers/account/scaffolding/completely_concrete/tangible_things_controller.rb
+++ b/app/controllers/account/scaffolding/completely_concrete/tangible_things_controller.rb
@@ -61,7 +61,9 @@ class Account::Scaffolding::CompletelyConcrete::TangibleThingsController < Accou
 
   private
 
-  include strong_parameters_from_api
+  if defined?(Api::V1::Application)
+    include strong_parameters_from_api
+  end
 
   def process_params(strong_params)
     # 🚅 skip this section when scaffolding.

--- a/app/controllers/account/scaffolding/completely_concrete/tangible_things_controller.rb
+++ b/app/controllers/account/scaffolding/completely_concrete/tangible_things_controller.rb
@@ -61,7 +61,7 @@ class Account::Scaffolding::CompletelyConcrete::TangibleThingsController < Accou
 
   private
 
-  if defined?(Api::V1::Application)
+  if defined?(Api::V1::ApplicationController)
     include strong_parameters_from_api
   end
 

--- a/app/controllers/api/v1/scaffolding/completely_concrete/tangible_things_controller.rb
+++ b/app/controllers/api/v1/scaffolding/completely_concrete/tangible_things_controller.rb
@@ -1,78 +1,87 @@
-class Api::V1::Scaffolding::CompletelyConcrete::TangibleThingsController < Api::V1::ApplicationController
-  account_load_and_authorize_resource :tangible_thing, through: :absolutely_abstract_creative_concept, through_association: :completely_concrete_tangible_things
+# Api::V1::ApplicationController is in the starter repository and isn't
+# needed for this package's unit tests, but our CI tests will try to load this
+# class because eager loading is set to `true` when CI=true.
+# We wrap this class in an `if` statement to circumvent this issue.
+if defined?(Api::V1::ApplicationController)
+  class Api::V1::Scaffolding::CompletelyConcrete::TangibleThingsController < Api::V1::ApplicationController
+    account_load_and_authorize_resource :tangible_thing, through: :absolutely_abstract_creative_concept, through_association: :completely_concrete_tangible_things
 
-  # GET /api/v1/scaffolding/absolutely_abstract/creative_concepts/:absolutely_abstract_creative_concept_id/completely_concrete/tangible_things
-  def index
-  end
-
-  # GET /api/v1/scaffolding/completely_concrete/tangible_things/:id
-  def show
-  end
-
-  # POST /api/v1/scaffolding/absolutely_abstract/creative_concepts/:absolutely_abstract_creative_concept_id/completely_concrete/tangible_things
-  def create
-    if @tangible_thing.save
-      render :show, status: :created, location: [:api, :v1, @tangible_thing]
-    else
-      render json: @tangible_thing.errors, status: :unprocessable_entity
+    # GET /api/v1/scaffolding/absolutely_abstract/creative_concepts/:absolutely_abstract_creative_concept_id/completely_concrete/tangible_things
+    def index
     end
-  end
 
-  # PATCH/PUT /api/v1/scaffolding/completely_concrete/tangible_things/:id
-  def update
-    if @tangible_thing.update(tangible_thing_params)
-      render :show
-    else
-      render json: @tangible_thing.errors, status: :unprocessable_entity
+    # GET /api/v1/scaffolding/completely_concrete/tangible_things/:id
+    def show
     end
-  end
 
-  # DELETE /api/v1/scaffolding/completely_concrete/tangible_things/:id
-  def destroy
-    @tangible_thing.destroy
-  end
-
-  private
-
-  module StrongParameters
-    # Only allow a list of trusted parameters through.
-    def tangible_thing_params
-      strong_params = params.require(:scaffolding_completely_concrete_tangible_thing).permit(
-        *permitted_fields,
-        # 🚅 skip this section when scaffolding.
-        :text_field_value,
-        :action_text_value,
-        :boolean_button_value,
-        :button_value,
-        :color_picker_value,
-        :cloudinary_image_value,
-        :date_field_value,
-        :date_and_time_field_value,
-        :date_and_time_field_value_time_zone,
-        :email_field_value,
-        :file_field_value,
-        :file_field_value_removal,
-        :option_value,
-        :password_field_value,
-        :phone_field_value,
-        :super_select_value,
-        :text_area_value,
-        # 🚅 stop any skipping we're doing now.
-        # 🚅 super scaffolding will insert new fields above this line.
-        *permitted_arrays,
-        # 🚅 skip this section when scaffolding.
-        multiple_button_values: [],
-        multiple_option_values: [],
-        multiple_super_select_values: []
-        # 🚅 stop any skipping we're doing now.
-        # 🚅 super scaffolding will insert new arrays above this line.
-      )
-
-      process_params(strong_params)
-
-      strong_params
+    # POST /api/v1/scaffolding/absolutely_abstract/creative_concepts/:absolutely_abstract_creative_concept_id/completely_concrete/tangible_things
+    def create
+      if @tangible_thing.save
+        render :show, status: :created, location: [:api, :v1, @tangible_thing]
+      else
+        render json: @tangible_thing.errors, status: :unprocessable_entity
+      end
     end
-  end
 
-  include StrongParameters
+    # PATCH/PUT /api/v1/scaffolding/completely_concrete/tangible_things/:id
+    def update
+      if @tangible_thing.update(tangible_thing_params)
+        render :show
+      else
+        render json: @tangible_thing.errors, status: :unprocessable_entity
+      end
+    end
+
+    # DELETE /api/v1/scaffolding/completely_concrete/tangible_things/:id
+    def destroy
+      @tangible_thing.destroy
+    end
+
+    private
+
+    module StrongParameters
+      # Only allow a list of trusted parameters through.
+      def tangible_thing_params
+        strong_params = params.require(:scaffolding_completely_concrete_tangible_thing).permit(
+          *permitted_fields,
+          # 🚅 skip this section when scaffolding.
+          :text_field_value,
+          :action_text_value,
+          :boolean_button_value,
+          :button_value,
+          :color_picker_value,
+          :cloudinary_image_value,
+          :date_field_value,
+          :date_and_time_field_value,
+          :date_and_time_field_value_time_zone,
+          :email_field_value,
+          :file_field_value,
+          :file_field_value_removal,
+          :option_value,
+          :password_field_value,
+          :phone_field_value,
+          :super_select_value,
+          :text_area_value,
+          # 🚅 stop any skipping we're doing now.
+          # 🚅 super scaffolding will insert new fields above this line.
+          *permitted_arrays,
+          # 🚅 skip this section when scaffolding.
+          multiple_button_values: [],
+          multiple_option_values: [],
+          multiple_super_select_values: []
+          # 🚅 stop any skipping we're doing now.
+          # 🚅 super scaffolding will insert new arrays above this line.
+        )
+
+        process_params(strong_params)
+
+        strong_params
+      end
+    end
+
+    include StrongParameters
+  end
+else
+  class Api::V1::Scaffolding::CompletelyConcrete::TangibleThingsController
+  end
 end


### PR DESCRIPTION
Closes #75.

## Background
As stated in https://github.com/bullet-train-co/bullet_train-base/pull/128, the tests are failing on CircleCI because eager loading is trying to load modules/classes that don't exist in these packages (namely the `StrongParameters` module per model, and `Api::V1::ApplicationController`). I've tried to bypass the parts where our code is calling these modules/classes in the most sensible way possible.

## Bypassing with `Api::V1::ApplicationController`
For the file with a bigger diff, I simply wrapped it with an if/else conditional.

I used the same fix in https://github.com/bullet-train-co/bullet_train-base/pull/128 for including strong parameters, but I'd like to ask how we should change this:
```ruby
if defined?(Api::V1::ApplicationController)
  include strong_parameters_from_api
end
```

The version number here isn't dynamic, so this will give us issues if a developer is using a different API version. However, I'm not sure which class to pass to this `if` statement. Maybe we should have a specific identifier whose purpose is to tells us if we have the context of the main application or not? Maybe there already is one that hasn't come to mind.

## Custom branches
I've added the following two custom branches to show that the tests are indeed passing, but we should remove these soon:
```ruby
gem "bullet_train", git: "git@github.com:bullet-train-co/bullet_train-base.git", branch: "ci-strong-params"
gem "bullet_train-api", git: "git@github.com:bullet-train-co/bullet_train-api.git", branch: "ci-strong-params"
```
