### PR TITLE
Fix opening link on GUI-less Linux

### DIFF
--- a/lib/bullet_train/super_scaffolding/scaffolders/oauth_provider_scaffolder.rb
+++ b/lib/bullet_train/super_scaffolding/scaffolders/oauth_provider_scaffolder.rb
@@ -61,7 +61,13 @@ module BulletTrain
             puts "When you find one you like, hover your mouse over it and then come back here and"
             puts "and enter the name of the icon you want to use."
             response = $stdin.gets.chomp
-            TerminalCommands.open_file_or_link("http://light.pinsupreme.com/icon_fonts_themefy.html")
+            if TerminalCommands.can_open?
+              TerminalCommands.open_file_or_link("http://light.pinsupreme.com/icon_fonts_themefy.html")
+            else
+              puts "Sorry! We can't open these URLs automatically on your platform, but you can visit them manually:"
+              puts ""
+              puts "  http://light.pinsupreme.com/icon_fonts_themefy.html"
+            end
             puts ""
             puts "Did you find an icon you wanted to use? Enter the name here or hit enter to just"
             puts "use the dollar symbol:"

--- a/lib/bullet_train/terminal_commands.rb
+++ b/lib/bullet_train/terminal_commands.rb
@@ -20,6 +20,11 @@ module TerminalCommands
     os == linux
   end
 
+  def self.can_open?
+    (TerminalCommands.macosx? && `which open`.present?) ||
+      (TerminalCommands.linux? && `which xdg-open`.present?)
+  end
+
   def self.macosx
     "darwin"
   end

--- a/lib/scaffolding/transformer.rb
+++ b/lib/scaffolding/transformer.rb
@@ -1487,7 +1487,7 @@ class Scaffolding::Transformer
             puts "enter the name of the icon you want to use."
             puts "(Or hit enter when choosing to skip this step.)"
             $stdin.gets.chomp
-            if (TerminalCommands.macosx? && `which open`.present?) || TerminalCommands.linux?
+            if TerminalCommands.can_open?
               TerminalCommands.open_file_or_link("https://themify.me/themify-icons")
               if font_awesome?
                 TerminalCommands.open_file_or_link("https://fontawesome.com/icons?d=gallery&s=light")


### PR DESCRIPTION
## Context

Scaffolding fails on Linux if `xdg-open` is not present (e.g., within a Docker container).

## Changes

- [x] Added `TerminalCommands.can_open?` to encapsulate open-ability checks

## Future thoughts

I would suggest going further and move the whole checking to the `.open_file_or_link` method along with the `puts`-fallback. But I'm hesitant since I don't know where this method could be used beyond the gem.
