### PR TITLE
Enable collection rendering for Super Scaffolded models

### DIFF
--- a/app/views/account/scaffolding/absolutely_abstract/creative_concepts/_creative_concept.html.erb
+++ b/app/views/account/scaffolding/absolutely_abstract/creative_concepts/_creative_concept.html.erb
@@ -10,8 +10,9 @@
     <td><%= display_date_and_time(creative_concept.created_at) %></td>
     <td class="buttons">
       <% unless hide_actions %>
-        <%= link_to t('.buttons.shorthand.edit'), [:edit, :account, creative_concept], class: 'button-secondary button-smaller' if can? :edit, creative_concept %>
-        <%= button_to t('.buttons.shorthand.destroy'), [:account, creative_concept], method: :delete, data: { confirm: t('.buttons.confirmations.destroy', model_locales(creative_concept)) }, class: 'button-secondary button-smaller' if can? :destroy, creative_concept %>
+        <%# We write the full path here since this partial is called from different scopes. %>
+        <%= link_to t('account.scaffolding.absolutely_abstract.creative_concepts.buttons.shorthand.edit'), [:edit, :account, creative_concept], class: 'button-secondary button-smaller' if can? :edit, creative_concept %>
+        <%= button_to t('account.scaffolding.absolutely_abstract.creative_concepts.buttons.shorthand.destroy'), [:account, creative_concept], method: :delete, data: { confirm: t('account.scaffolding.absolutely_abstract.creative_concepts.buttons.confirmations.destroy', model_locales(creative_concept)) }, class: 'button-secondary button-smaller' if can? :destroy, creative_concept %>
       <% end %>
     </td>
   </tr>

--- a/app/views/account/scaffolding/absolutely_abstract/creative_concepts/_creative_concept.html.erb
+++ b/app/views/account/scaffolding/absolutely_abstract/creative_concepts/_creative_concept.html.erb
@@ -1,0 +1,18 @@
+<% context ||= @team %>
+<% hide_actions ||= false %>
+<% hide_back ||= false %>
+
+<% with_attribute_settings object: creative_concept do %>
+  <tr data-id="<%= creative_concept.id %>">
+    <td><%= render 'shared/attributes/text', attribute: :name, url: [:account, creative_concept] %></td>
+    <td><%= render 'account/shared/memberships/photos', memberships: creative_concept.all_collaborators, size: 9, align: :center %></td>
+    <%# 🚅 super scaffolding will insert new fields above this line. %>
+    <td><%= display_date_and_time(creative_concept.created_at) %></td>
+    <td class="buttons">
+      <% unless hide_actions %>
+        <%= link_to t('.buttons.shorthand.edit'), [:edit, :account, creative_concept], class: 'button-secondary button-smaller' if can? :edit, creative_concept %>
+        <%= button_to t('.buttons.shorthand.destroy'), [:account, creative_concept], method: :delete, data: { confirm: t('.buttons.confirmations.destroy', model_locales(creative_concept)) }, class: 'button-secondary button-smaller' if can? :destroy, creative_concept %>
+      <% end %>
+    </td>
+  </tr>
+<% end %>

--- a/app/views/account/scaffolding/absolutely_abstract/creative_concepts/_index.html.erb
+++ b/app/views/account/scaffolding/absolutely_abstract/creative_concepts/_index.html.erb
@@ -23,22 +23,7 @@
             </tr>
           </thead>
           <tbody>
-            <% creative_concepts.each do |creative_concept| %>
-              <% with_attribute_settings object: creative_concept do %>
-                <tr data-id="<%= creative_concept.id %>">
-                  <td><%= render 'shared/attributes/text', attribute: :name, url: [:account, creative_concept] %></td>
-                  <td><%= render 'account/shared/memberships/photos', memberships: creative_concept.all_collaborators, size: 9, align: :center %></td>
-                  <%# 🚅 super scaffolding will insert new fields above this line. %>
-                  <td><%= display_date_and_time(creative_concept.created_at) %></td>
-                  <td class="buttons">
-                    <% unless hide_actions %>
-                      <%= link_to t('.buttons.shorthand.edit'), [:edit, :account, creative_concept], class: 'button-secondary button-smaller' if can? :edit, creative_concept %>
-                      <%= button_to t('.buttons.shorthand.destroy'), [:account, creative_concept], method: :delete, data: { confirm: t('.buttons.confirmations.destroy', model_locales(creative_concept)) }, class: 'button-secondary button-smaller' if can? :destroy, creative_concept %>
-                    <% end %>
-                  </td>
-                </tr>
-              <% end %>
-            <% end %>
+            <%= yield %>
           </tbody>
         </table>
       <% end %>

--- a/app/views/account/scaffolding/absolutely_abstract/creative_concepts/index.html.erb
+++ b/app/views/account/scaffolding/absolutely_abstract/creative_concepts/index.html.erb
@@ -1,6 +1,8 @@
 <%= render 'account/shared/page' do |p| %>
   <% p.content_for :title, t('.section') %>
   <% p.content_for :body do %>
-    <%= render 'index', creative_concepts: @creative_concepts %>
+    <%= render 'index', creative_concepts: @creative_concepts do %>
+      <%= render @creative_concepts %>
+    <% end %>
   <% end %>
 <% end %>

--- a/app/views/account/scaffolding/absolutely_abstract/creative_concepts/show.html.erb
+++ b/app/views/account/scaffolding/absolutely_abstract/creative_concepts/show.html.erb
@@ -54,7 +54,14 @@
       <% end %>
     <% end %>
 
-    <%= render 'account/scaffolding/completely_concrete/tangible_things/index', tangible_things: @creative_concept.completely_concrete_tangible_things.accessible_by(current_ability), hide_back: true %>
+    <% tangible_things = @creative_concept.completely_concrete_tangible_things.accessible_by(current_ability) %>
+    <% pagy, tangible_things = pagy(tangible_things, page_param: :tangible_things_page) %>
+    <%= render 'account/scaffolding/completely_concrete/tangible_things/index', tangible_things: tangible_things, pagy: pagy, hide_back: true do %>
+      <%# We can't do collection rendering here because the path is in a different directory. %>
+      <% tangible_things.each do |tangible_thing| %>
+        <%= render 'account/scaffolding/completely_concrete/tangible_things/tangible_thing', tangible_things: tangible_things, tangible_thing: tangible_thing %>
+      <% end %>
+    <% end %>
 
     <% if can? :read, Scaffolding::AbsolutelyAbstract::CreativeConcepts::Collaborator.new(creative_concept: @creative_concept) %>
       <%= render 'account/scaffolding/absolutely_abstract/creative_concepts/collaborators/index', collaborators: @creative_concept.collaborators, hide_back: true %>

--- a/app/views/account/scaffolding/completely_concrete/tangible_things/_index.html.erb
+++ b/app/views/account/scaffolding/completely_concrete/tangible_things/_index.html.erb
@@ -34,32 +34,7 @@
               </tr>
             </thead>
             <tbody>
-              <% tangible_things.each do |tangible_thing| %>
-                <% with_attribute_settings object: tangible_thing do %>
-                  <tr data-id="<%= tangible_thing.id %>">
-                    <%= render "shared/tables/checkbox", object: tangible_thing %>
-                    <%# 🚅 skip this section when scaffolding. %>
-                    <td><%= render 'shared/attributes/text', attribute: :text_field_value, url: [:account, tangible_thing] %></td>
-                    <td><%= render 'shared/attributes/boolean', attribute: :boolean_button_value %></td>
-                    <td><%= render 'shared/attributes/option', attribute: :button_value %></td>
-                    <td><%= render 'shared/attributes/options', attribute: :multiple_button_values %></td>
-                    <%# 🚅 stop any skipping we're doing now. %>
-                    <%# 🚅 super scaffolding will insert new fields above this line. %>
-                    <td><%= render 'shared/attributes/date_and_time', attribute: :created_at %></td>
-                    <td class="buttons">
-                      <% unless hide_actions %>
-                        <% if can? :edit, tangible_thing %>
-                          <%= link_to t('.buttons.shorthand.edit'), [:edit, :account, tangible_thing], class: 'button-secondary button-smaller' %>
-                        <% end %>
-                        <% if can? :destroy, tangible_thing %>
-                          <%= button_to t('.buttons.shorthand.destroy'), [:account, tangible_thing], method: :delete, data: { confirm: t('.buttons.confirmations.destroy', model_locales(tangible_thing)) }, class: 'button-secondary button-smaller' %>
-                        <% end %>
-                        <%# 🚅 super scaffolding will insert new action model buttons above this line. %>
-                      <% end %>
-                    </td>
-                  </tr>
-                <% end %>
-              <% end %>
+              <%= yield %>
             </tbody>
           </table>
         <% end %>

--- a/app/views/account/scaffolding/completely_concrete/tangible_things/_index.html.erb
+++ b/app/views/account/scaffolding/completely_concrete/tangible_things/_index.html.erb
@@ -4,8 +4,9 @@
 <% hide_actions ||= false %>
 <% hide_back ||= false %>
 
-<% tangible_things = tangible_things.order(:id) unless has_order?(tangible_things) %>
-<% pagy, tangible_things = pagy(tangible_things, page_param: :tangible_things_page) %>
+<% unless defined?(pagy) %>
+  <% pagy, tangible_things = pagy(tangible_things, page_param: :tangible_things_page) %>
+<% end %>
 
 <%= action_model_select_controller do %>
   <%= updates_for context, collection do %>

--- a/app/views/account/scaffolding/completely_concrete/tangible_things/_tangible_thing.html.erb
+++ b/app/views/account/scaffolding/completely_concrete/tangible_things/_tangible_thing.html.erb
@@ -1,0 +1,30 @@
+<% absolutely_abstract_creative_concept = @absolutely_abstract_creative_concept || @creative_concept %>
+<% context ||= absolutely_abstract_creative_concept %>
+<% collection ||= :completely_concrete_tangible_things %>
+<% hide_actions ||= false %>
+<% hide_back ||= false %>
+
+<% with_attribute_settings object: tangible_thing do %>
+  <tr data-id="<%= tangible_thing.id %>">
+    <%= render "shared/tables/checkbox", object: tangible_thing %>
+    <%# 🚅 skip this section when scaffolding. %>
+    <td><%= render 'shared/attributes/text', attribute: :text_field_value, url: [:account, tangible_thing] %></td>
+    <td><%= render 'shared/attributes/boolean', attribute: :boolean_button_value %></td>
+    <td><%= render 'shared/attributes/option', attribute: :button_value %></td>
+    <td><%= render 'shared/attributes/options', attribute: :multiple_button_values %></td>
+    <%# 🚅 stop any skipping we're doing now. %>
+    <%# 🚅 super scaffolding will insert new fields above this line. %>
+    <td><%= render 'shared/attributes/date_and_time', attribute: :created_at %></td>
+    <td class="buttons">
+      <% unless hide_actions %>
+        <% if can? :edit, tangible_thing %>
+          <%= link_to t('.buttons.shorthand.edit'), [:edit, :account, tangible_thing], class: 'button-secondary button-smaller' %>
+        <% end %>
+        <% if can? :destroy, tangible_thing %>
+          <%= button_to t('.buttons.shorthand.destroy'), [:account, tangible_thing], method: :delete, data: { confirm: t('.buttons.confirmations.destroy', model_locales(tangible_thing)) }, class: 'button-secondary button-smaller' %>
+        <% end %>
+        <%# 🚅 super scaffolding will insert new action model buttons above this line. %>
+      <% end %>
+    </td>
+  </tr>
+<% end %>

--- a/app/views/account/scaffolding/completely_concrete/tangible_things/_tangible_thing.html.erb
+++ b/app/views/account/scaffolding/completely_concrete/tangible_things/_tangible_thing.html.erb
@@ -18,10 +18,10 @@
     <td class="buttons">
       <% unless hide_actions %>
         <% if can? :edit, tangible_thing %>
-          <%= link_to t('.buttons.shorthand.edit'), [:edit, :account, tangible_thing], class: 'button-secondary button-smaller' %>
+          <%= link_to t('account.scaffolding.completely_concrete.tangible_things.buttons.shorthand.edit'), [:edit, :account, tangible_thing], class: 'button-secondary button-smaller' %>
         <% end %>
         <% if can? :destroy, tangible_thing %>
-          <%= button_to t('.buttons.shorthand.destroy'), [:account, tangible_thing], method: :delete, data: { confirm: t('.buttons.confirmations.destroy', model_locales(tangible_thing)) }, class: 'button-secondary button-smaller' %>
+          <%= button_to t('account.scaffolding.completely_concrete.tangible_things.buttons.shorthand.destroy'), [:account, tangible_thing], method: :delete, data: { confirm: t('account.scaffolding.completely_concrete.tangible_things.buttons.confirmations.destroy', model_locales(tangible_thing)) }, class: 'button-secondary button-smaller' %>
         <% end %>
         <%# 🚅 super scaffolding will insert new action model buttons above this line. %>
       <% end %>

--- a/app/views/account/scaffolding/completely_concrete/tangible_things/index.html.erb
+++ b/app/views/account/scaffolding/completely_concrete/tangible_things/index.html.erb
@@ -1,8 +1,10 @@
 <%= render 'account/shared/page' do |p| %>
   <% p.content_for :title, t('.section') %>
   <% p.content_for :body do %>
-    <%= render 'index', tangible_things: @tangible_things do %>
-      <%= render @tangible_things %>
+    <% pagy, tangible_things = pagy(@tangible_things, page_param: :tangible_things_page) %>
+
+    <%= render 'index', tangible_things: @tangible_things, pagy: pagy do %>
+      <%= render tangible_things %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/account/scaffolding/completely_concrete/tangible_things/index.html.erb
+++ b/app/views/account/scaffolding/completely_concrete/tangible_things/index.html.erb
@@ -1,6 +1,8 @@
 <%= render 'account/shared/page' do |p| %>
   <% p.content_for :title, t('.section') %>
   <% p.content_for :body do %>
-    <%= render 'index', tangible_things: @tangible_things %>
+    <%= render 'index', tangible_things: @tangible_things do %>
+      <%= render @tangible_things %>
+    <% end %>
   <% end %>
 <% end %>

--- a/lib/scaffolding/class_names_transformer.rb
+++ b/lib/scaffolding/class_names_transformer.rb
@@ -100,6 +100,11 @@ class Scaffolding::ClassNamesTransformer
       parent.pluralize.titlecase.tr("/", " ")
     when "Scaffolding Completely Concrete Tangible Things"
       child.pluralize.titlecase.tr("/", " ")
+
+    # This is a specific example for locales where we only leave tangible_things.
+    when "scaffolding.completely_concrete.tangible_things"
+      child.underscore.pluralize
+
     when "Scaffolding/Absolutely Abstract/Creative Concepts"
       parent.pluralize.titlecase
     when "Scaffolding/Completely Concrete/Tangible Things"

--- a/lib/scaffolding/transformer.rb
+++ b/lib/scaffolding/transformer.rb
@@ -930,7 +930,7 @@ class Scaffolding::Transformer
         ERB
 
         unless ["Team", "User"].include?(child)
-          scaffold_add_line_to_file("./app/views/account/scaffolding/completely_concrete/tangible_things/_index.html.erb", field_content.strip, ERB_NEW_FIELDS_HOOK, prepend: true)
+          scaffold_add_line_to_file("./app/views/account/scaffolding/completely_concrete/tangible_things/_tangible_thing.html.erb", field_content.strip, ERB_NEW_FIELDS_HOOK, prepend: true)
         end
 
       end

--- a/lib/scaffolding/transformer.rb
+++ b/lib/scaffolding/transformer.rb
@@ -1276,7 +1276,8 @@ class Scaffolding::Transformer
     files = if cli_options["only-index"]
       [
         "./app/views/account/scaffolding/completely_concrete/tangible_things/_index.html.erb",
-        "./app/views/account/scaffolding/completely_concrete/tangible_things/index.html.erb"
+        "./app/views/account/scaffolding/completely_concrete/tangible_things/index.html.erb",
+        "./app/views/account/scaffolding/completely_concrete/tangible_things/_tangible_thing.html.erb"
       ]
     else
       # copy a ton of files over and do the appropriate string replace.

--- a/lib/scaffolding/transformer.rb
+++ b/lib/scaffolding/transformer.rb
@@ -7,6 +7,12 @@ class Scaffolding::Transformer
   attr_accessor :child, :parent, :parents, :class_names_transformer, :cli_options, :additional_steps, :namespace, :suppress_could_not_find
 
   def code_for_child_on_parent_show_page
+    <<~ERB
+      <% pagy, tangible_things = pagy(@team.tangible_things, page_param: :tangible_things_page) %>
+      <%= render 'account/tangible_things/index', tangible_things: tangible_things, hide_back: true, pagy: pagy do %>
+        <%= render tangible_things %>
+      <% end %>
+    ERB
   end
 
   def update_models_abstract_class
@@ -101,6 +107,7 @@ class Scaffolding::Transformer
       "scaffolding_completely_concrete_tangible_thing",
       "scaffolding-absolutely-abstract-creative-concept",
       "scaffolding-completely-concrete-tangible-thing",
+      "scaffolding.completely_concrete.tangible_things",
 
       # class name in context plural.
       "absolutely_abstract_creative_concepts",


### PR DESCRIPTION
Closes https://github.com/bullet-train-co/bullet_train-base/issues/129

Joint PRs
- https://github.com/bullet-train-co/bullet_train-themes/pull/23
- https://github.com/bullet-train-co/bullet_train/pull/467

I'm having some trouble with Pagy, but this is the basic setup for getting collection rendering to work for Super Scaffolded models. There are some variable definitions at the beginning of these partials:

```erb
<% context ||= @team %>
<% hide_actions ||= false %>
<% hide_back ||= false %>
```

I'll have to sift through these a little bit more just to make sure they're in the right places.