### PR TITLE
Super Scaffold file fields so they are serialized properly

### DIFF
--- a/app/views/api/v1/scaffolding/completely_concrete/tangible_things/_tangible_thing.json.jbuilder
+++ b/app/views/api/v1/scaffolding/completely_concrete/tangible_things/_tangible_thing.json.jbuilder
@@ -20,3 +20,5 @@ json.extract! tangible_thing,
   # 🚅 super scaffolding will insert new fields above this line.
   :created_at,
   :updated_at
+
+# 🚅 super scaffolding will insert file-related logic above this line.

--- a/lib/scaffolding/transformer.rb
+++ b/lib/scaffolding/transformer.rb
@@ -1048,7 +1048,9 @@ class Scaffolding::Transformer
 
         # TODO The serializers can't handle these `has_rich_text` attributes.
         unless type == "trix_editor"
-          scaffold_add_line_to_file("./app/views/api/v1/scaffolding/completely_concrete/tangible_things/_tangible_thing.json.jbuilder", ":#{name},", RUBY_NEW_FIELDS_HOOK, prepend: true, suppress_could_not_find: true)
+          unless type == "file_field"
+            scaffold_add_line_to_file("./app/views/api/v1/scaffolding/completely_concrete/tangible_things/_tangible_thing.json.jbuilder", ":#{name},", RUBY_NEW_FIELDS_HOOK, prepend: true, suppress_could_not_find: true)
+          end
 
           assertion = case type
           when "date_field"
@@ -1056,8 +1058,7 @@ class Scaffolding::Transformer
           when "date_and_time_field"
             "assert_equal_or_nil DateTime.parse(tangible_thing_data['#{name}']), tangible_thing.#{name}"
           when "file_field"
-            # TODO Get this working again.
-            "# assert tangible_thing_data['#{name}'].match?('foo.txt') unless response.status == 201"
+            "assert_equal tangible_thing_data['#{name}'], rails_blob_path(@tangible_thing.#{name})"
           else
             "assert_equal_or_nil tangible_thing_data['#{name}'], tangible_thing.#{name}"
           end
@@ -1066,10 +1067,13 @@ class Scaffolding::Transformer
 
         # File fields are handled in a specific way when using the jsonapi-serializer.
         if type == "file_field"
-          # TODO Get this working again.
+          scaffold_add_line_to_file("./app/views/api/v1/scaffolding/completely_concrete/tangible_things/_tangible_thing.json.jbuilder", "json.#{name} url_for(tangible_thing.#{name}) if tangible_thing.#{name}.attached?", RUBY_FILES_HOOK, prepend: true, suppress_could_not_find: true)
           # We also want to make sure we attach the dummy file in the API test on setup
           file_name = "./test/controllers/api/v1/scaffolding/completely_concrete/tangible_things_controller_test.rb"
-          content = "# @#{child.underscore}.#{name} = Rack::Test::UploadedFile.new(\"test/support/foo.txt\")"
+          content = <<~RUBY
+            @#{child.underscore}.#{name} = Rack::Test::UploadedFile.new(\"test/support/foo.txt\")
+            @another_#{child.underscore}.#{name} = Rack::Test::UploadedFile.new(\"test/support/foo.txt\")
+          RUBY
           scaffold_add_line_to_file(file_name, content, RUBY_FILES_HOOK, prepend: true)
         end
 

--- a/lib/scaffolding/transformer.rb
+++ b/lib/scaffolding/transformer.rb
@@ -1058,7 +1058,7 @@ class Scaffolding::Transformer
           when "date_and_time_field"
             "assert_equal_or_nil DateTime.parse(tangible_thing_data['#{name}']), tangible_thing.#{name}"
           when "file_field"
-            "assert_equal tangible_thing_data['#{name}'], rails_blob_path(@tangible_thing.#{name})"
+            "assert_equal tangible_thing_data['#{name}'], rails_blob_path(@tangible_thing.#{name}) unless controller.action_name == 'create'"
           else
             "assert_equal_or_nil tangible_thing_data['#{name}'], tangible_thing.#{name}"
           end


### PR DESCRIPTION
Addresses the TODO in the Transformer about getting the previous file field serialization tests to work again.

Joint PR
- https://github.com/bullet-train-co/bullet_train/pull/478

## Details
Since we're not using serializer files anymore, I had to do a little research to get things working with Jbuilder. The only thing I'm somewhat bothered by is that `url_for` works fine for getting the url in the Jbuilder file, but I had to use `rails_blob_path` in the actual test to get the same string. This Rails issue, [ActiveStorage with Rails API](https://github.com/rails/rails/issues/32500), had some information to go off of. One of the comments says that the `rails_blob_path` and `rails_blob_url` helpers "provide a permanent link to a blob," so we should be fine with the current setup.

As far as the controller test, I had to shuffle around the order of the variables in the original tangible things API controller test in the joint PR. The reason for this is that `@another_tangible_thing` was also being checked for a file attachment, but we weren't attaching anything in the `setup` block.