### PR TITLE
Remove equal sign causing duplicate code, add comment to helper

### DIFF
--- a/app/helpers/super_scaffolding_helper.rb
+++ b/app/helpers/super_scaffolding_helper.rb
@@ -1,10 +1,13 @@
 module SuperScaffoldingHelper
   unless defined?(BulletTrain::ActionModels)
+    # action_model_select_controller is originally a method
+    # in the Action Models package, but we can't simply
+    # remove this method from Super Scaffolded index partials
+    # when the package isn't present. Since we keep
+    # action_model_select_controller in our views, we need
+    # this method so we don't get a NoMethodError.
     def action_model_select_controller
-      # TODO I don't know why if I just call `yield` I get duplicate content on the page.
-      tag.div do
-        yield
-      end
+      yield
     end
   end
 end

--- a/app/views/account/scaffolding/completely_concrete/tangible_things/_index.html.erb
+++ b/app/views/account/scaffolding/completely_concrete/tangible_things/_index.html.erb
@@ -8,7 +8,7 @@
 <% pagy, tangible_things = pagy(tangible_things, page_param: :tangible_things_page) %>
 
 <%= action_model_select_controller do %>
-  <%= updates_for context, collection do %>
+  <% updates_for context, collection do %>
     <%= render 'account/shared/box', pagy: pagy do |p| %>
       <% p.content_for :title, t(".contexts.#{context.class.name.underscore}.header") %>
       <% p.content_for :description do %>


### PR DESCRIPTION
Addresses the TODO in `app/helpers/super_scaffolding_helper.rb`

## Details
Looking at the page source from the original code, you can see that `updates-for` is being rendered twice:
![Screenshot from 2022-10-18 20-44-57](https://user-images.githubusercontent.com/10546292/196420758-f92e8e6f-2c3b-4da0-949c-d1f30710165e.png)

I eventually came to the conclusion that it was because we were using an extra equal sign, although I first thought it was with `action_model_select_controller`. Granted, it DID work with that method by removing the equal sign, but this caused the Action Model code to not show. Removing the `=` from `updates-for` instead will cause everything to render correctly when Action Models is both present and not present. 

## Wrapped `yield` versus raw `yield`
I think the reason the `tag.div` code worked was because it was adding an extra layer that needed to be rendered, causing the `<%= ... %>` erb to work fine. However, if we were just passing a raw `yield` to it, it seemed to be rendering the code that was already there, along with the extra `yield`.