### PR TITLE
Add Message for Crud Action

### DIFF
--- a/lib/bullet_train/super_scaffolding/scaffolders/crud_scaffolder.rb
+++ b/lib/bullet_train/super_scaffolding/scaffolders/crud_scaffolder.rb
@@ -27,6 +27,8 @@ module BulletTrain
             puts ""
             puts "Give it a shot! Let us know if you have any trouble with it! ✌️"
             puts ""
+            puts "Testing the Bullet Train contribution process."
+            puts ""
             exit
           end
 


### PR DESCRIPTION
This PR deals with modifying the Super Scaffolding code so when we run `bin/super-scaffold crud`, additional message prints out with the help message saying `Testing the Bullet Train contribution process`