### PR TITLE
Notify users about testing message

### DIFF
--- a/lib/bullet_train/super_scaffolding/scaffolders/crud_scaffolder.rb
+++ b/lib/bullet_train/super_scaffolding/scaffolders/crud_scaffolder.rb
@@ -27,6 +27,8 @@ module BulletTrain
             puts ""
             puts "Give it a shot! Let us know if you have any trouble with it! ✌️"
             puts ""
+            puts "Testing the Bullet Train contribution process." # Added temporarily for testing by Amit
+            puts ""
             exit
           end
 

--- a/lib/scaffolding/script.rb
+++ b/lib/scaffolding/script.rb
@@ -99,10 +99,6 @@ def show_usage
   puts ""
 end
 
-# Added temporarily for testing
-puts ""
-puts "Testing the Bullet Train contribution process."
-
 # grab the _type_ of scaffold we're doing.
 scaffolding_type = argv.shift
 

--- a/lib/scaffolding/script.rb
+++ b/lib/scaffolding/script.rb
@@ -99,6 +99,10 @@ def show_usage
   puts ""
 end
 
+# Added temporarily for testing
+puts ""
+puts "Testing the Bullet Train contribution process."
+
 # grab the _type_ of scaffold we're doing.
 scaffolding_type = argv.shift
 


### PR DESCRIPTION
This PR adds an additional message at the end with the help message saying **“Testing the Bullet Train contribution process.”** when you run `bin/super-scaffold crud` runs.

Note - This message is printed every time the script `bin/super-scaffold crud` is run, ~~This doesn't print only for the `crud` command.~~