### PR TITLE
Fix link to Super Scaffolding docs

### DIFF
--- a/config/locales/en/scaffolding/absolutely_abstract/creative_concepts.en.yml
+++ b/config/locales/en/scaffolding/absolutely_abstract/creative_concepts.en.yml
@@ -74,7 +74,7 @@ en:
         <code>Scaffolding::AbsolutelyAbstract::CreativeConcept</code> is a model that exists by default in Bullet Train to serve as part of Super Scaffolding's template system.
         It also provides an example of what a scaffolded model looks like by default.
         Yes, the class has a very weird name, but the weird name serves an important purpose when we're generating code.
-        For more details and instructions on how to hide this, see "<a href="https://tailwind.bullettrain.co/docs/super-scaffolding">Code Generation with Super Scaffolding</a>".
+        For more details and instructions on how to hide this, see "<a href="https://bullettrain.co/docs/super-scaffolding">Code Generation with Super Scaffolding</a>".
     show:
       section: "%{creative_concept_name}"
       header: Creative Concept Details


### PR DESCRIPTION
Current link is broken, replaced with working link to Super Scaffolding docs.