### PR TITLE
Insert multiple lines with `BlockManipulator#insert`, handle line breaks

### DIFF
--- a/lib/scaffolding/block_manipulator.rb
+++ b/lib/scaffolding/block_manipulator.rb
@@ -42,25 +42,30 @@ module Scaffolding::BlockManipulator
   end
 
   def self.insert(content, lines:, within: nil, after: nil, before: nil, after_block: nil, append: false)
+    content = prepare_content_array(content)
+
+    # We initialize the search with the entire file's lines and look for the block below.
+    start_line = 0
+    end_line = lines.count - 1
+
     # Search for before like we do after, we'll just inject before it.
     after ||= before
 
     # If within is given, find the start and end lines of the block
-    content += "\n" unless content.match?(/\n$/)
-    start_line = 0
-    end_line = lines.count - 1
     if within.present?
       start_line = find_block_start(starting_from: within, lines: lines)
       end_line = find_block_end(starting_from: start_line, lines: lines)
       # start_line += 1 # ensure we actually insert the content _within_ the given block
       # end_line += 1 if end_line == start_line
     end
+
     if after_block.present?
       block_start = find_block_start(starting_from: after_block, lines: lines)
       block_end = find_block_end(starting_from: block_start, lines: lines)
       start_line = block_end
       end_line = lines.count - 1
     end
+
     index = start_line
     match = false
     while index < end_line && !match
@@ -68,8 +73,10 @@ module Scaffolding::BlockManipulator
       if after.nil? || line.match?(after)
         unless append
           match = true
+          indent = !(before.present? || after.present? || after_block.present?)
+
           # We adjust the injection point if we really wanted to insert before.
-          lines = insert_line(content, index - (before ? 1 : 0), lines)
+          lines = insert_lines(content, index - (before ? 1 : 0), lines, indent)
         end
       end
       index += 1
@@ -79,29 +86,38 @@ module Scaffolding::BlockManipulator
 
     # Match should always be false here.
     if append && !match
-      lines = insert_line(content, index - 1, lines)
+      lines = insert_lines(content, index - 1, lines)
     end
     lines
   end
 
-  def self.insert_line(content, insert_at_index, lines)
-    content += "\n" unless content.match?(/\n$/)
+  def self.insert_lines(content, insert_at_index, lines, indent)
     final = []
     lines.each_with_index do |line, index|
-      indent = line.match(/^\s*/).to_s
+      indentation = line.match(/^\s*/).to_s
+      indentation += "\s" * 2 if indent
+
       final << line
-      if index == insert_at_index
-        final << indent + content
-      end
+      content.each { |new_line| final << indentation + new_line } if index == insert_at_index
     end
     final
   end
 
+  # TODO: We should eventually replace this with `insert_lines``,
+  # I just want to make sure everything doesn't break first.
+  def self.insert_line(content, insert_at_index, lines, indent = true)
+    insert_lines(prepare_content_array(content), insert_at_index, lines, indent)
+  end
+
   def self.insert_block(block_content, after_block:, lines:)
+    # Since `after_block` must be present for this method to work,
+    # the assumption is we never insert a block inside an empty block, but
+    # always after the end of one. For that reason, indent defaults to false.
+    indent = false
     block_start = find_block_start(starting_from: after_block, lines: lines)
     block_end = find_block_end(starting_from: block_start, lines: lines)
-    lines = insert_line(block_content[0], block_end, lines)
-    insert_line(block_content[1], block_end + 1, lines)
+    lines = insert_line(block_content[0], block_end, lines, indent)
+    insert_line(block_content[1], block_end + 1, lines, indent)
   end
 
   def self.find_block_parent(starting_line_number, lines)
@@ -158,5 +174,18 @@ module Scaffolding::BlockManipulator
     lines[line_number].match(/^( +)/)[1]
   rescue
     nil
+  end
+
+  private
+
+  def self.prepare_content_array(content)
+    # Ensure content is an Array
+    content = [content].flatten
+
+    # Ensure there are no stray new lines within each string
+    content = content.map { |line| line.split("\n") }.flatten
+
+    # Ensure each new line has a line break at the end.
+    content.map { |line| line.match?(/\n$/) ? line : "#{line}\n" }
   end
 end

--- a/lib/scaffolding/block_manipulator.rb
+++ b/lib/scaffolding/block_manipulator.rb
@@ -1,191 +1,195 @@
 require "scaffolding/file_manipulator"
 
-module Scaffolding::BlockManipulator
-  #
-  # Wrap a block of ruby code with another block on the outside.
-  #
-  # @param [String] `starting` A string to search for at the start of the block. Eg "<%= updates_for context, collection do"
-  # @param [Array] `with` An array with two String elements. The text that should wrap the block. Eg ["<%= action_model_select_controller do %>", "<% end %>"]
-  #
-  def self.wrap_block(starting:, with:, lines:)
-    with[0] += "\n" unless with[0].match?(/\n$/)
-    with[1] += "\n" unless with[1].match?(/\n$/)
-    starting_line = find_block_start(starting_from: starting, lines: lines)
-    end_line = find_block_end(starting_from: starting_line, lines: lines)
+module Scaffolding
+  class BlockManipulator
+    class << self
+      #
+      # Wrap a block of ruby code with another block on the outside.
+      #
+      # @param [String] `starting` A string to search for at the start of the block. Eg "<%= updates_for context, collection do"
+      # @param [Array] `with` An array with two String elements. The text that should wrap the block. Eg ["<%= action_model_select_controller do %>", "<% end %>"]
+      #
+      def wrap_block(starting:, with:, lines:)
+        with[0] += "\n" unless with[0].match?(/\n$/)
+        with[1] += "\n" unless with[1].match?(/\n$/)
+        starting_line = find_block_start(starting_from: starting, lines: lines)
+        end_line = find_block_end(starting_from: starting_line, lines: lines)
 
-    final = []
-    block_indent = ""
-    spacer = "  "
-    lines.each_with_index do |line, index|
-      line += "\n" unless line.match?(/\n$/)
-      if index < starting_line
-        final << line
-      elsif index == starting_line
-        block_indent = line.match(/^\s*/).to_s
-        final << block_indent + with[0]
-        final << (line.blank? ? "\n" : "#{spacer}#{line}")
-      elsif index > starting_line && index < end_line
-        final << (line.blank? ? "\n" : "#{spacer}#{line}")
-      elsif index == end_line
-        final << (line.blank? ? "\n" : "#{spacer}#{line}")
-        final << block_indent + with[1]
-      else
-        final << line
-      end
-    end
-
-    lines = final
-    unless lines.last.match?(/\n$/)
-      lines[-1] += "\n"
-    end
-    lines
-  end
-
-  def self.insert(content, lines:, within: nil, after: nil, before: nil, after_block: nil, append: false)
-    content = prepare_content_array(content)
-
-    # We initialize the search with the entire file's lines and look for the block below.
-    start_line = 0
-    end_line = lines.count - 1
-
-    # Search for before like we do after, we'll just inject before it.
-    after ||= before
-
-    # If within is given, find the start and end lines of the block
-    if within.present?
-      start_line = find_block_start(starting_from: within, lines: lines)
-      end_line = find_block_end(starting_from: start_line, lines: lines)
-      # start_line += 1 # ensure we actually insert the content _within_ the given block
-      # end_line += 1 if end_line == start_line
-    end
-
-    if after_block.present?
-      block_start = find_block_start(starting_from: after_block, lines: lines)
-      block_end = find_block_end(starting_from: block_start, lines: lines)
-      start_line = block_end
-      end_line = lines.count - 1
-    end
-
-    index = start_line
-    match = false
-    while index < end_line && !match
-      line = lines[index]
-      if after.nil? || line.match?(after)
-        unless append
-          match = true
-          indent = !(before.present? || after.present? || after_block.present?)
-
-          # We adjust the injection point if we really wanted to insert before.
-          lines = insert_lines(content, index - (before ? 1 : 0), lines, indent)
+        final = []
+        block_indent = ""
+        spacer = "  "
+        lines.each_with_index do |line, index|
+          line += "\n" unless line.match?(/\n$/)
+          if index < starting_line
+            final << line
+          elsif index == starting_line
+            block_indent = line.match(/^\s*/).to_s
+            final << block_indent + with[0]
+            final << (line.blank? ? "\n" : "#{spacer}#{line}")
+          elsif index > starting_line && index < end_line
+            final << (line.blank? ? "\n" : "#{spacer}#{line}")
+          elsif index == end_line
+            final << (line.blank? ? "\n" : "#{spacer}#{line}")
+            final << block_indent + with[1]
+          else
+            final << line
+          end
         end
+
+        lines = final
+        unless lines.last.match?(/\n$/)
+          lines[-1] += "\n"
+        end
+        lines
       end
-      index += 1
-    end
 
-    return lines if match
+      def insert(content, lines:, within: nil, after: nil, before: nil, after_block: nil, append: false)
+        content = prepare_content_array(content)
 
-    # Match should always be false here.
-    if append && !match
-      lines = insert_lines(content, index - 1, lines)
-    end
-    lines
-  end
+        # We initialize the search with the entire file's lines and look for the block below.
+        start_line = 0
+        end_line = lines.count - 1
 
-  def self.insert_lines(content, insert_at_index, lines, indent)
-    final = []
-    lines.each_with_index do |line, index|
-      indentation = line.match(/^\s*/).to_s
-      indentation += "\s" * 2 if indent
+        # Search for before like we do after, we'll just inject before it.
+        after ||= before
 
-      final << line
-      content.each { |new_line| final << indentation + new_line } if index == insert_at_index
-    end
-    final
-  end
+        # If within is given, find the start and end lines of the block
+        if within.present?
+          start_line = find_block_start(starting_from: within, lines: lines)
+          end_line = find_block_end(starting_from: start_line, lines: lines)
+          # start_line += 1 # ensure we actually insert the content _within_ the given block
+          # end_line += 1 if end_line == start_line
+        end
 
-  # TODO: We should eventually replace this with `insert_lines``,
-  # I just want to make sure everything doesn't break first.
-  def self.insert_line(content, insert_at_index, lines, indent = true)
-    insert_lines(prepare_content_array(content), insert_at_index, lines, indent)
-  end
+        if after_block.present?
+          block_start = find_block_start(starting_from: after_block, lines: lines)
+          block_end = find_block_end(starting_from: block_start, lines: lines)
+          start_line = block_end
+          end_line = lines.count - 1
+        end
 
-  def self.insert_block(block_content, after_block:, lines:)
-    # Since `after_block` must be present for this method to work,
-    # the assumption is we never insert a block inside an empty block, but
-    # always after the end of one. For that reason, indent defaults to false.
-    indent = false
-    block_start = find_block_start(starting_from: after_block, lines: lines)
-    block_end = find_block_end(starting_from: block_start, lines: lines)
-    lines = insert_line(block_content[0], block_end, lines, indent)
-    insert_line(block_content[1], block_end + 1, lines, indent)
-  end
+        index = start_line
+        match = false
+        while index < end_line && !match
+          line = lines[index]
+          if after.nil? || line.match?(after)
+            unless append
+              match = true
+              indent = !(before.present? || after.present? || after_block.present?)
 
-  def self.find_block_parent(starting_line_number, lines)
-    return nil unless indentation_of(starting_line_number, lines)
-    cursor = starting_line_number
-    while cursor >= 0
-      unless lines[cursor].match?(/^#{indentation_of(starting_line_number, lines)}/) || !lines[cursor].present?
-        return cursor
+              # We adjust the injection point if we really wanted to insert before.
+              lines = insert_lines(content, index - (before ? 1 : 0), lines, indent)
+            end
+          end
+          index += 1
+        end
+
+        return lines if match
+
+        # Match should always be false here.
+        if append && !match
+          lines = insert_lines(content, index - 1, lines)
+        end
+        lines
       end
-      cursor -= 1
-    end
-    nil
-  end
 
-  def self.find_block_start(starting_from:, lines:)
-    matcher = Regexp.escape(starting_from)
-    starting_line = 0
+      def insert_lines(content, insert_at_index, lines, indent)
+        final = []
+        lines.each_with_index do |line, index|
+          indentation = line.match(/^\s*/).to_s
+          indentation += "\s" * 2 if indent
 
-    lines.each_with_index do |line, index|
-      if line.match?(matcher)
-        starting_line = index
-        break
+          final << line
+          content.each { |new_line| final << indentation + new_line } if index == insert_at_index
+        end
+        final
+      end
+
+      # TODO: We should eventually replace this with `insert_lines``,
+      # I just want to make sure everything doesn't break first.
+      def insert_line(content, insert_at_index, lines, indent = true)
+        insert_lines(prepare_content_array(content), insert_at_index, lines, indent)
+      end
+
+      def insert_block(block_content, after_block:, lines:)
+        # Since `after_block` must be present for this method to work,
+        # the assumption is we never insert a block inside an empty block, but
+        # always after the end of one. For that reason, indent defaults to false.
+        indent = false
+        block_start = find_block_start(starting_from: after_block, lines: lines)
+        block_end = find_block_end(starting_from: block_start, lines: lines)
+        lines = insert_line(block_content[0], block_end, lines, indent)
+        insert_line(block_content[1], block_end + 1, lines, indent)
+      end
+
+      def find_block_parent(starting_line_number, lines)
+        return nil unless indentation_of(starting_line_number, lines)
+        cursor = starting_line_number
+        while cursor >= 0
+          unless lines[cursor].match?(/^#{indentation_of(starting_line_number, lines)}/) || !lines[cursor].present?
+            return cursor
+          end
+          cursor -= 1
+        end
+        nil
+      end
+
+      def find_block_start(starting_from:, lines:)
+        matcher = Regexp.escape(starting_from)
+        starting_line = 0
+
+        lines.each_with_index do |line, index|
+          if line.match?(matcher)
+            starting_line = index
+            break
+          end
+        end
+        starting_line
+      end
+
+      def find_block_end(starting_from:, lines:)
+        # This loop was previously in the RoutesFileManipulator.
+        lines.each_with_index do |line, line_number|
+          next unless line_number > starting_from
+          if /^#{indentation_of(starting_from, lines)}end\s+/.match?(line)
+            return line_number
+          end
+        end
+
+        depth = 0
+        current_line = starting_from
+        lines[starting_from..lines.count].each_with_index do |line, index|
+          current_line = starting_from + index
+          depth += 1 if line.match?(/\s*<%.+ do .*%>/)
+          depth += 1 if line.match?(/\s*<% if .*%>/)
+          depth += 1 if line.match?(/\s*<% unless .*%>/)
+          depth -= 1 if line.match?(/\s*<%.* end .*%>/)
+          break current_line if depth == 0
+        end
+        current_line
+      end
+
+      # TODO: We shouldn't need this second argument, but since
+      # we have `lines` here and in the RoutesFileManipulator,
+      # the lines diverge from one another when we edit them individually.
+      def indentation_of(line_number, lines)
+        lines[line_number].match(/^( +)/)[1]
+      rescue
+        nil
+      end
+
+      private
+
+      def prepare_content_array(content)
+        # Ensure content is an Array
+        content = [content].flatten
+
+        # Ensure there are no stray new lines within each string
+        content = content.map { |line| line.split("\n") }.flatten
+
+        # Ensure each new line has a line break at the end.
+        content.map { |line| line.match?(/\n$/) ? line : "#{line}\n" }
       end
     end
-    starting_line
-  end
-
-  def self.find_block_end(starting_from:, lines:)
-    # This loop was previously in the RoutesFileManipulator.
-    lines.each_with_index do |line, line_number|
-      next unless line_number > starting_from
-      if /^#{indentation_of(starting_from, lines)}end\s+/.match?(line)
-        return line_number
-      end
-    end
-
-    depth = 0
-    current_line = starting_from
-    lines[starting_from..lines.count].each_with_index do |line, index|
-      current_line = starting_from + index
-      depth += 1 if line.match?(/\s*<%.+ do .*%>/)
-      depth += 1 if line.match?(/\s*<% if .*%>/)
-      depth += 1 if line.match?(/\s*<% unless .*%>/)
-      depth -= 1 if line.match?(/\s*<%.* end .*%>/)
-      break current_line if depth == 0
-    end
-    current_line
-  end
-
-  # TODO: We shouldn't need this second argument, but since
-  # we have `lines` here and in the RoutesFileManipulator,
-  # the lines diverge from one another when we edit them individually.
-  def self.indentation_of(line_number, lines)
-    lines[line_number].match(/^( +)/)[1]
-  rescue
-    nil
-  end
-
-  private
-
-  def self.prepare_content_array(content)
-    # Ensure content is an Array
-    content = [content].flatten
-
-    # Ensure there are no stray new lines within each string
-    content = content.map { |line| line.split("\n") }.flatten
-
-    # Ensure each new line has a line break at the end.
-    content.map { |line| line.match?(/\n$/) ? line : "#{line}\n" }
   end
 end

--- a/test/lib/scaffolding/block_manipulator_test.rb
+++ b/test/lib/scaffolding/block_manipulator_test.rb
@@ -49,6 +49,69 @@ describe Scaffolding::BlockManipulator do
     assert_equal(File.read(file_path), expected_result)
   end
 
+  it "inserts multiple lines within a block using the proper indentation" do
+    initial_data =
+      <<~INITIAL
+
+        <% test_block do %>
+        <% end %>
+
+      INITIAL
+    initialize_demo_file(file_path, initial_data)
+    initial_lines = File.readlines(file_path)
+
+    content = ["first", "second", "third"]
+    new_lines = Scaffolding::BlockManipulator.insert(content, within: "<% test_block do %>", lines: initial_lines)
+    Scaffolding::FileManipulator.write(file_path, new_lines, strip: false)
+
+    expected_result =
+      <<~RESULT
+
+        <% test_block do %>
+          first
+          second
+          third
+        <% end %>
+
+      RESULT
+    assert_equal(File.readlines(file_path), new_lines)
+    assert_equal(File.read(file_path), expected_result)
+  end
+
+  it "inserts multiple lines within a block when using a heredoc" do
+    initial_data =
+      <<~INITIAL
+
+        <% test_block do %>
+        <% end %>
+
+      INITIAL
+    initialize_demo_file(file_path, initial_data)
+    initial_lines = File.readlines(file_path)
+
+    content = <<~CONTENT
+      first
+      second
+      third
+    CONTENT
+
+    new_lines = Scaffolding::BlockManipulator.insert(content, within: "<% test_block do %>", lines: initial_lines)
+    Scaffolding::FileManipulator.write(file_path, new_lines, strip: false)
+
+    expected_result =
+      <<~RESULT
+
+        <% test_block do %>
+          first
+          second
+          third
+        <% end %>
+
+      RESULT
+    assert_equal(File.readlines(file_path), new_lines)
+    assert_equal(File.read(file_path), expected_result)
+  end
+
   it "inserts into an empty block" do
     initial_data =
       <<~INITIAL
@@ -62,7 +125,7 @@ describe Scaffolding::BlockManipulator do
     initialize_demo_file(file_path, initial_data)
     initial_lines = File.readlines(file_path)
 
-    new_lines = Scaffolding::BlockManipulator.insert("  Some new content", within: "<% inner_block", lines: initial_lines)
+    new_lines = Scaffolding::BlockManipulator.insert("Some new content", within: "<% inner_block", lines: initial_lines)
     Scaffolding::FileManipulator.write(file_path, new_lines, strip: false)
 
     expected_result =
@@ -177,7 +240,7 @@ describe Scaffolding::BlockManipulator do
     initial_lines = File.readlines(file_path)
 
     new_lines = Scaffolding::BlockManipulator.insert_block(["<% new_block do %>", "<% end %>"], after_block: "<% inner_block", lines: initial_lines)
-    new_lines = Scaffolding::BlockManipulator.insert("  an inner line", within: "<% new_block", lines: new_lines)
+    new_lines = Scaffolding::BlockManipulator.insert("an inner line", within: "<% new_block", lines: new_lines)
     Scaffolding::FileManipulator.write(file_path, new_lines, strip: false)
 
     expected_result =


### PR DESCRIPTION
Closes #96.

## Changes
1. Pass an array to `insert` so you can insert multiple lines at once (still supports simply passing a string)
2. Split the content by new line breaks if they exist (specifically so we can support heredocs in `insert`)
3. Change `BlockManipulator` to a class and wrap in `class << self ... end` so we don't have to prefix every method with `self.`

## Tests
The tests show how these new changes work, but I'll leave another example here:
```ruby
data = <<~DATA
<% test_block do %>
<% end %>
DATA

content = ["first", "second", "third"]
Scaffolding::BlockManipulator.insert(content, within: "<% test_block do %>", lines: data)

# This yields the following:
[
  "<% test_block do %>",
  "  first",
  "  second",
  "  third",
  "<% end %>"
]
```