### PR TITLE
Fix Regexp in `BlockManipulator#find_block_end`

### DIFF
--- a/lib/scaffolding/block_manipulator.rb
+++ b/lib/scaffolding/block_manipulator.rb
@@ -133,7 +133,7 @@ module Scaffolding::BlockManipulator
     # This loop was previously in the RoutesFileManipulator.
     lines.each_with_index do |line, line_number|
       next unless line_number > starting_from
-      if /^#{indentation_of(starting_from, lines)}end\s+/.match?(line)
+      if /^#{indentation_of(starting_from, lines)}end\s*/.match?(line)
         return line_number
       end
     end


### PR DESCRIPTION
## The problem
If we don't use the `within` option when using the `insert` method, `find_block_end` is never used, so the content is inserted in the right place:
```ruby
lines = [
  "def foo",
  "end"
]
content = "puts 'bar'"
Scaffolding::BlockManipulator.insert(content, lines: lines)
#=> ["def foo", "puts 'bar'\n", "end"]
```

However, When trying to do this with the `within` option, it doesn't work because we DO use the `find_block_end` method which had a bug in it:
```ruby
Scaffolding::BlockManipulator.insert(content, lines: lines, within: "def foo")
#=> ["def foo", "end"]
```

## The fix
This was happening because we were requiring white space in the regular expression that tried to find the block end, so I just changed the `+` to `*`.
